### PR TITLE
Fix Midtown rehearsal sync blockers

### DIFF
--- a/api/src/models/contracts/configuration.py
+++ b/api/src/models/contracts/configuration.py
@@ -28,7 +28,7 @@ class ConfigurationTypeCreate(BaseModel):
 class ConfigurationTypePublic(BaseModel):
     """Configuration type public response model (global, not org-scoped)."""
 
-    id: str
+    id: UUID
     name: str
     is_active: bool
     created_at: datetime
@@ -53,7 +53,7 @@ class ConfigurationStatusCreate(BaseModel):
 class ConfigurationStatusPublic(BaseModel):
     """Configuration status public response model (global, not org-scoped)."""
 
-    id: str
+    id: UUID
     name: str
     is_active: bool
     created_at: datetime

--- a/api/src/models/contracts/custom_asset.py
+++ b/api/src/models/contracts/custom_asset.py
@@ -109,7 +109,7 @@ class CustomAssetTypePublic(BaseModel):
 
     model_config = ConfigDict(from_attributes=True)
 
-    id: str
+    id: UUID
     name: str
     fields: list[FieldDefinition]
     sort_order: int = 0

--- a/api/src/models/contracts/relationship.py
+++ b/api/src/models/contracts/relationship.py
@@ -3,8 +3,9 @@ Relationship contracts (API request/response schemas).
 """
 
 from datetime import datetime
+from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_serializer
 
 
 class RelationshipCreate(BaseModel):
@@ -27,13 +28,17 @@ class RelationshipPublic(BaseModel):
 
     model_config = ConfigDict(from_attributes=True)
 
-    id: str
-    organization_id: str
+    id: UUID
+    organization_id: UUID
     source_type: str
-    source_id: str
+    source_id: UUID
     target_type: str
-    target_id: str
+    target_id: UUID
     created_at: datetime
+
+    @field_serializer("id", "organization_id", "source_id", "target_id")
+    def serialize_uuid(self, v: UUID) -> str:
+        return str(v)
 
 
 class RelatedEntity(BaseModel):

--- a/api/tests/unit/models/contracts/test_response_uuid_serialization.py
+++ b/api/tests/unit/models/contracts/test_response_uuid_serialization.py
@@ -1,0 +1,75 @@
+"""Response contract UUID serialization tests."""
+
+from datetime import UTC, datetime
+from uuid import uuid4
+
+from src.models.contracts.configuration import (
+    ConfigurationStatusPublic,
+    ConfigurationTypePublic,
+)
+from src.models.contracts.custom_asset import CustomAssetTypePublic
+from src.models.contracts.relationship import RelationshipPublic
+
+
+def test_global_type_responses_accept_uuid_ids() -> None:
+    """Global type response models should accept ORM UUID values."""
+    type_id = uuid4()
+    status_id = uuid4()
+    now = datetime.now(UTC)
+
+    config_type = ConfigurationTypePublic(
+        id=type_id,
+        name="Firewall",
+        is_active=True,
+        created_at=now,
+    )
+    config_status = ConfigurationStatusPublic(
+        id=status_id,
+        name="Active",
+        is_active=True,
+        created_at=now,
+    )
+
+    assert config_type.model_dump(mode="json")["id"] == str(type_id)
+    assert config_status.model_dump(mode="json")["id"] == str(status_id)
+
+
+def test_custom_asset_type_response_accepts_uuid_id() -> None:
+    """Custom asset type response model should accept ORM UUID values."""
+    type_id = uuid4()
+    now = datetime.now(UTC)
+
+    custom_asset_type = CustomAssetTypePublic(
+        id=type_id,
+        name="Licensing",
+        fields=[],
+        is_active=True,
+        created_at=now,
+        updated_at=now,
+    )
+
+    assert custom_asset_type.model_dump(mode="json")["id"] == str(type_id)
+
+
+def test_relationship_response_accepts_uuid_ids() -> None:
+    """Relationship response model should accept ORM UUID values."""
+    relationship_id = uuid4()
+    org_id = uuid4()
+    source_id = uuid4()
+    target_id = uuid4()
+
+    relationship = RelationshipPublic(
+        id=relationship_id,
+        organization_id=org_id,
+        source_type="password",
+        source_id=source_id,
+        target_type="configuration",
+        target_id=target_id,
+        created_at=datetime.now(UTC),
+    )
+
+    dumped = relationship.model_dump(mode="json")
+    assert dumped["id"] == str(relationship_id)
+    assert dumped["organization_id"] == str(org_id)
+    assert dumped["source_id"] == str(source_id)
+    assert dumped["target_id"] == str(target_id)

--- a/tools/itglue-migrate/src/itglue_migrate/cli.py
+++ b/tools/itglue-migrate/src/itglue_migrate/cli.py
@@ -2920,12 +2920,18 @@ async def _run_sync(
                 console.print()
                 console.print("[yellow]DRY RUN - No changes made[/yellow]")
                 if report:
+                    doc_processor: DocumentProcessor | None = None
+                    if export_path:
+                        doc_processor = DocumentProcessor(client, export_path)
                     executor = SyncExecutor(
                         client,  # type: ignore[arg-type]
                         org_id=org_uuid,
                         dry_run=True,
                         state=state,
                         update_existing=update_existing,
+                        doc_processor=doc_processor,
+                        export_path=export_path,
+                        skip_attachments=True,
                     )
                     result = await executor.execute(plan)
                     total_result.errors.extend(result.errors)

--- a/tools/itglue-migrate/src/itglue_migrate/sync_executor.py
+++ b/tools/itglue-migrate/src/itglue_migrate/sync_executor.py
@@ -656,6 +656,35 @@ class SyncExecutor:
 
             # SECOND: Check for empty content (after attempting to load from file)
             if _is_content_empty(raw_content):
+                attachment_files = []
+                if self.doc_processor and self.export_path:
+                    try:
+                        attachment_files = self.doc_processor.scanner.get_entity_attachments(
+                            self.export_path,
+                            "documents",
+                            itglue_id,
+                        )
+                    except Exception as e:
+                        logger.warning(
+                            "Failed to inspect attachments for document %s in %s: %s",
+                            itglue_id,
+                            self.export_path,
+                            e,
+                        )
+                if attachment_files:
+                    raw_content = (
+                        "_Attachment-only document imported from IT Glue. "
+                        "The export did not include an HTML body; see attachments._"
+                    )
+                else:
+                    result.skipped["documents"] = result.skipped.get("documents", 0) + 1
+                    logger.debug(f"Skipping document '{doc_name}': empty content")
+                    if self.reporter:
+                        self.reporter.update_progress(skipped=1)
+                        self.reporter.warning(f"Document '{doc_name}' has empty content")
+                    continue
+
+            if _is_content_empty(raw_content):
                 result.skipped["documents"] = result.skipped.get("documents", 0) + 1
                 logger.debug(f"Skipping document '{doc_name}': empty content")
                 if self.reporter:

--- a/tools/itglue-migrate/tests/unit/test_sync_executor.py
+++ b/tools/itglue-migrate/tests/unit/test_sync_executor.py
@@ -179,6 +179,120 @@ class TestSyncExecutorDryRun:
         mock_client.create_document.assert_not_called()
         mock_client.create_password.assert_not_called()
 
+    @pytest.mark.asyncio
+    async def test_dry_run_counts_document_loaded_from_export_html(
+        self, mock_client: MagicMock
+    ) -> None:
+        """Dry run should use DocumentProcessor content before empty checks."""
+        plan = SyncPlan()
+        plan.documents.to_create = [{"id": "doc-3", "name": "Exported Document"}]
+        doc_processor = MagicMock()
+        doc_processor.load_document_content.return_value = "<p>Exported content</p>"
+
+        executor = SyncExecutor(
+            mock_client,
+            org_id="org-uuid",
+            dry_run=True,
+            doc_processor=doc_processor,
+        )
+        result = await executor.execute(plan)
+
+        assert result.created.get("documents", 0) == 1
+        assert result.skipped.get("documents", 0) == 0
+        doc_processor.load_document_content.assert_called_once_with("doc-3")
+        mock_client.create_document.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_dry_run_counts_empty_document_with_attachments(
+        self, mock_client: MagicMock, tmp_path
+    ) -> None:
+        """Attachment-only exported documents should not be skipped."""
+        plan = SyncPlan()
+        plan.documents.to_create = [{"id": "doc-4", "name": "Attached PDF"}]
+        attachment = tmp_path / "attached.pdf"
+        attachment.write_bytes(b"%PDF-1.4")
+        doc_processor = MagicMock()
+        doc_processor.load_document_content.return_value = ""
+        doc_processor.scanner.get_entity_attachments.return_value = [attachment]
+
+        executor = SyncExecutor(
+            mock_client,
+            org_id="org-uuid",
+            dry_run=True,
+            doc_processor=doc_processor,
+            export_path=tmp_path,
+        )
+        result = await executor.execute(plan)
+
+        assert result.created.get("documents", 0) == 1
+        assert result.skipped.get("documents", 0) == 0
+        doc_processor.scanner.get_entity_attachments.assert_called_once_with(
+            tmp_path,
+            "documents",
+            "doc-4",
+        )
+        mock_client.create_document.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_dry_run_skips_when_attachment_scan_fails(
+        self, mock_client: MagicMock, tmp_path
+    ) -> None:
+        """Attachment scan errors should not abort document sync."""
+        plan = SyncPlan()
+        plan.documents.to_create = [{"id": "doc-5", "name": "Broken Attachment Scan"}]
+        doc_processor = MagicMock()
+        doc_processor.load_document_content.return_value = ""
+        doc_processor.scanner.get_entity_attachments.side_effect = OSError("scan failed")
+
+        executor = SyncExecutor(
+            mock_client,
+            org_id="org-uuid",
+            dry_run=True,
+            doc_processor=doc_processor,
+            export_path=tmp_path,
+        )
+        result = await executor.execute(plan)
+
+        assert result.created.get("documents", 0) == 0
+        assert result.skipped.get("documents", 0) == 1
+        mock_client.create_document.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_execute_creates_attachment_only_document(
+        self, mock_client: MagicMock, tmp_path
+    ) -> None:
+        """Live sync should create attachment-only documents before uploads."""
+        plan = SyncPlan()
+        plan.documents.to_create = [{"id": "doc-6", "name": "Attached Runbook"}]
+        attachment = tmp_path / "runbook.pdf"
+        attachment.write_bytes(b"%PDF-1.4")
+        doc_processor = MagicMock()
+        doc_processor.load_document_content.return_value = ""
+        doc_processor.document_folder_map = {}
+        doc_processor.process_document = AsyncMock(return_value=("", []))
+        doc_processor.scanner.get_entity_attachments.return_value = [attachment]
+        doc_processor.upload_entity_attachments = AsyncMock(return_value=1)
+
+        executor = SyncExecutor(
+            mock_client,
+            org_id="org-uuid",
+            dry_run=False,
+            doc_processor=doc_processor,
+            export_path=tmp_path,
+        )
+        result = await executor.execute(plan)
+
+        assert result.created.get("documents", 0) == 1
+        assert result.skipped.get("documents", 0) == 0
+        mock_client.create_document.assert_called_once()
+        assert "Attachment-only document" in mock_client.create_document.call_args.kwargs["content"]
+        doc_processor.upload_entity_attachments.assert_awaited_once_with(
+            entity_type="documents",
+            entity_id="doc-6",
+            org_uuid="org-uuid",
+            our_entity_id="new-doc-uuid",
+        )
+
 
 class TestSyncExecutorExecuteLocations:
     """Tests for executing location sync."""


### PR DESCRIPTION
## Summary
- wire document processing into sync dry-run reconciliation so exported HTML is counted before empty-content checks
- preserve attachment-only IT Glue documents by creating a document shell when attachments exist
- fix API response contracts that rejected ORM UUIDs for global types and relationships

## Test Plan
- `PYTHONPATH=tools/itglue-migrate/src python -m pytest tools/itglue-migrate/tests/unit/test_sync_executor.py -q`
- `PYTHONPATH=api python -m pytest api/tests/unit/models/contracts/test_response_uuid_serialization.py -q`
- Midtown dry-run against staged export produced zero errors and improved documents from 288 created / 183 skipped to 446 created / 25 skipped

## Rehearsal Notes
The first live pilot exposed these contract issues after partially importing Midtown. Dev should be wiped before rerunning the live pilot after this lands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API models now accept UUID values for several ID fields while responses continue to return string IDs.
  * Migration tool dry-run: improved document handling so attachment-only items are detected and processed (attachments suppressed in dry-run).

* **Tests**
  * Added unit tests for UUID serialization in API responses.
  * Added tests covering document creation and attachment-only behavior in migration flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->