### PR TITLE
Fix custom asset UUID response contracts

### DIFF
--- a/api/src/models/contracts/custom_asset.py
+++ b/api/src/models/contracts/custom_asset.py
@@ -158,7 +158,7 @@ class CustomAssetPublic(PublicEntityBase):
     Password fields are excluded from values.
     """
 
-    custom_asset_type_id: str
+    custom_asset_type_id: UUID
     values: dict[str, Any]  # password fields excluded
     sync_metadata: SyncMetadata | None = None
     updated_by_user_id: str | None = None
@@ -177,7 +177,7 @@ class CustomAssetReveal(PublicEntityBase):
     Includes decrypted password field values.
     """
 
-    custom_asset_type_id: str
+    custom_asset_type_id: UUID
     values: dict[str, Any]  # includes decrypted password fields
     sync_metadata: SyncMetadata | None = None
     updated_by_user_id: str | None = None

--- a/api/tests/unit/models/contracts/test_response_uuid_serialization.py
+++ b/api/tests/unit/models/contracts/test_response_uuid_serialization.py
@@ -7,7 +7,11 @@ from src.models.contracts.configuration import (
     ConfigurationStatusPublic,
     ConfigurationTypePublic,
 )
-from src.models.contracts.custom_asset import CustomAssetTypePublic
+from src.models.contracts.custom_asset import (
+    CustomAssetPublic,
+    CustomAssetReveal,
+    CustomAssetTypePublic,
+)
 from src.models.contracts.relationship import RelationshipPublic
 
 
@@ -49,6 +53,26 @@ def test_custom_asset_type_response_accepts_uuid_id() -> None:
     )
 
     assert custom_asset_type.model_dump(mode="json")["id"] == str(type_id)
+
+
+def test_custom_asset_responses_accept_uuid_foreign_keys() -> None:
+    """Custom asset response models should accept ORM UUID foreign keys."""
+    asset_type_id = uuid4()
+    common = {
+        "id": uuid4(),
+        "organization_id": uuid4(),
+        "custom_asset_type_id": asset_type_id,
+        "values": {"name": "Example"},
+        "is_enabled": True,
+        "created_at": datetime.now(UTC),
+        "updated_at": datetime.now(UTC),
+    }
+
+    public = CustomAssetPublic(**common)
+    reveal = CustomAssetReveal(**common)
+
+    assert public.model_dump(mode="json")["custom_asset_type_id"] == str(asset_type_id)
+    assert reveal.model_dump(mode="json")["custom_asset_type_id"] == str(asset_type_id)
 
 
 def test_relationship_response_accepts_uuid_ids() -> None:


### PR DESCRIPTION
## Summary
- allow custom asset response contracts to accept ORM UUID values for `custom_asset_type_id`
- add regression coverage for public and reveal custom asset responses

## Test Plan
- `PYTHONPATH=api python -m pytest api/tests/unit/models/contracts/test_response_uuid_serialization.py -q`
- `python -m ruff check api/src/models/contracts/custom_asset.py api/tests/unit/models/contracts/test_response_uuid_serialization.py tools/itglue-migrate/src/itglue_migrate/sync_executor.py tools/itglue-migrate/tests/unit/test_sync_executor.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrected custom asset type ID field type in API response contracts for improved type consistency.

* **Tests**
  * Added test coverage to verify UUID foreign keys in custom asset responses are properly validated and serialized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->