### PR TITLE
Add Azure Neon proof deployment path

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,6 +35,8 @@ BIFROST_DOCS_DEBUG=false
 
 # Redis URL (override for production)
 # BIFROST_DOCS_REDIS_URL=redis://valkey:6379/0
+# Disable only for proof deployments that intentionally run without Redis.
+# BIFROST_DOCS_RATE_LIMITING_ENABLED=true
 
 # =============================================================================
 # CORS

--- a/.env.example
+++ b/.env.example
@@ -95,6 +95,21 @@ GARAGE_SECRET_ACCESS_KEY=your-secret-access-key
 BIFROST_DOCS_S3_BUCKET=bifrost-docs
 
 # =============================================================================
+# Azure Blob Storage (Azure + Neon proof)
+# =============================================================================
+
+# Set to azure_blob to use Azure Storage instead of S3/Garage.
+# BIFROST_DOCS_STORAGE_BACKEND=azure_blob
+
+# Either provide a connection string or an account URL + account key.
+# BIFROST_DOCS_AZURE_STORAGE_CONNECTION_STRING=
+# BIFROST_DOCS_AZURE_STORAGE_ACCOUNT_URL=https://youraccount.blob.core.windows.net
+# BIFROST_DOCS_AZURE_STORAGE_ACCOUNT_KEY=
+# BIFROST_DOCS_AZURE_BLOB_CONTAINER=attachments
+# BIFROST_DOCS_AZURE_BLOB_SAS_EXPIRY=600
+# BIFROST_DOCS_AZURE_BLOB_DOWNLOAD_SAS_EXPIRY=3600
+
+# =============================================================================
 # OpenAI (for vector search)
 # =============================================================================
 

--- a/.github/workflows/azure-neon-proof-image.yml
+++ b/.github/workflows/azure-neon-proof-image.yml
@@ -1,0 +1,43 @@
+name: Azure Neon Proof API Image
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Image tag to publish
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  API_IMAGE_NAME: mtg-thomas/bifrost-docs-api
+
+jobs:
+  build-api-image:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push proof API image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./api
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.API_IMAGE_NAME }}:${{ inputs.tag }}
+          cache-from: type=gha,scope=api-proof
+          cache-to: type=gha,mode=max,scope=api-proof

--- a/.github/workflows/azure-neon-proof-image.yml
+++ b/.github/workflows/azure-neon-proof-image.yml
@@ -21,20 +21,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push proof API image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: ./api
           push: true

--- a/.github/workflows/azure-neon-proof-swa.yml
+++ b/.github/workflows/azure-neon-proof-swa.yml
@@ -6,16 +6,19 @@ on:
 permissions:
   contents: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   deploy:
     name: Deploy frontend to Azure Static Web Apps
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "22"
           cache: npm

--- a/.github/workflows/azure-neon-proof-swa.yml
+++ b/.github/workflows/azure-neon-proof-swa.yml
@@ -1,0 +1,41 @@
+name: Azure Neon Proof SWA
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    name: Deploy frontend to Azure Static Web Apps
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: client/package-lock.json
+
+      - name: Install dependencies
+        working-directory: client
+        run: npm ci
+
+      - name: Build frontend
+        working-directory: client
+        env:
+          VITE_API_URL: https://ca-bifrost-docs-api-neon-dev.icymoss-8e8097f1.eastus.azurecontainerapps.io
+        run: npm run build
+
+      - name: Deploy to Azure Static Web Apps
+        uses: Azure/static-web-apps-deploy@v1
+        with:
+          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_BIFROST_DOCS_NEON_DEV }}
+          action: upload
+          app_location: client/dist
+          skip_app_build: true
+          skip_api_build: true

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -64,7 +64,7 @@ jobs:
           echo "deploy_ref=${DEPLOY_REF}" >> "$GITHUB_OUTPUT"
 
       - name: Checkout deployment ref
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ steps.ref.outputs.deploy_ref }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,6 +132,45 @@ jobs:
           NODE_ENV: production
 
   # =============================================================================
+  # Proof Deployment - Azure Static Web Apps
+  # =============================================================================
+  deploy-swa-proof:
+    runs-on: ubuntu-latest
+    needs: frontend-checks
+    if: github.event_name == 'workflow_dispatch'
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: './client/package-lock.json'
+
+      - name: Install dependencies
+        working-directory: ./client
+        run: npm ci
+
+      - name: Build proof bundle
+        working-directory: ./client
+        run: npm run build
+        env:
+          NODE_ENV: production
+          VITE_API_URL: https://ca-bifrost-docs-api-neon-dev.icymoss-8e8097f1.eastus.azurecontainerapps.io
+
+      - name: Deploy to Azure Static Web Apps
+        uses: Azure/static-web-apps-deploy@v1
+        with:
+          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_BIFROST_DOCS_NEON_DEV }}
+          action: upload
+          app_location: client/dist
+          skip_app_build: true
+          skip_api_build: true
+
+  # =============================================================================
   # Build & Push Docker Images
   # =============================================================================
   build-images:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,7 +137,9 @@ jobs:
   build-images:
     runs-on: ubuntu-latest
     needs: [backend-checks, frontend-checks]
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: >-
+      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      github.event_name == 'workflow_dispatch'
     
     permissions:
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,12 @@ env:
   REGISTRY: ghcr.io
   API_IMAGE_NAME: mtg-thomas/bifrost-docs-api
   CLIENT_IMAGE_NAME: mtg-thomas/bifrost-docs-client
+  AZURE_NEON_PROOF_CLIENT_ID: 8b0fa37b-e02c-425e-8db7-a8494fbbc6fd
+  AZURE_NEON_PROOF_TENANT_ID: a3599b15-c39c-4b41-a219-7e24dd5b5190
+  AZURE_NEON_PROOF_SUBSCRIPTION_ID: a1d63b24-1202-4bfa-9086-cf32d1d352fc
+  AZURE_NEON_PROOF_RESOURCE_GROUP: rg-bifrost-docs-neon-dev
+  AZURE_NEON_PROOF_CONTAINER_APP: ca-bifrost-docs-api-neon-dev
+  AZURE_NEON_PROOF_API_URL: https://ca-bifrost-docs-api-neon-dev.icymoss-8e8097f1.eastus.azurecontainerapps.io
 
 jobs:
   # =============================================================================
@@ -243,6 +249,58 @@ jobs:
           cache-to: type=gha,mode=max,scope=client
           sbom: true
           provenance: true
+
+  # =============================================================================
+  # Proof Deployment - Azure Container Apps API
+  # =============================================================================
+  deploy-api-proof:
+    runs-on: ubuntu-latest
+    needs: build-images
+    if: github.event_name == 'workflow_dispatch'
+    environment: azure-neon-proof
+
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Resolve proof image
+        id: image
+        run: |
+          IMAGE_TAG="${GITHUB_SHA::7}"
+          IMAGE="${REGISTRY}/${API_IMAGE_NAME}:${IMAGE_TAG}"
+          echo "tag=${IMAGE_TAG}" >> "$GITHUB_OUTPUT"
+          echo "image=${IMAGE}" >> "$GITHUB_OUTPUT"
+          echo "Deploying ${IMAGE}"
+
+      - name: Log in to Azure with OIDC
+        uses: azure/login@v2
+        with:
+          client-id: ${{ env.AZURE_NEON_PROOF_CLIENT_ID }}
+          tenant-id: ${{ env.AZURE_NEON_PROOF_TENANT_ID }}
+          subscription-id: ${{ env.AZURE_NEON_PROOF_SUBSCRIPTION_ID }}
+
+      - name: Deploy API image to Azure Container Apps
+        run: |
+          az containerapp update \
+            --resource-group "${AZURE_NEON_PROOF_RESOURCE_GROUP}" \
+            --name "${AZURE_NEON_PROOF_CONTAINER_APP}" \
+            --image "${{ steps.image.outputs.image }}"
+
+      - name: Verify API health
+        run: |
+          for attempt in {1..24}; do
+            if curl --fail --silent --show-error "${AZURE_NEON_PROOF_API_URL}/health"; then
+              echo
+              echo "API health check passed on attempt ${attempt}."
+              exit 0
+            fi
+            echo "API health check attempt ${attempt} failed; waiting..."
+            sleep 10
+          done
+
+          echo "API health check did not pass within the rollout window." >&2
+          exit 1
 
   # =============================================================================
   # E2E Smoke Tests (Run after images are built)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ on:
   workflow_dispatch: # Allow manual triggers
 
 env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   REGISTRY: ghcr.io
   API_IMAGE_NAME: mtg-thomas/bifrost-docs-api
   CLIENT_IMAGE_NAME: mtg-thomas/bifrost-docs-client
@@ -63,10 +64,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
           cache: 'pip'
@@ -114,10 +115,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'npm'
@@ -147,10 +148,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'npm'
@@ -192,13 +193,13 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -206,7 +207,7 @@ jobs:
 
       - name: Extract metadata for API
         id: api-meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.API_IMAGE_NAME }}
           tags: |
@@ -217,7 +218,7 @@ jobs:
 
       - name: Extract metadata for Client
         id: client-meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.CLIENT_IMAGE_NAME }}
           tags: |
@@ -227,7 +228,7 @@ jobs:
             latest
 
       - name: Build and push API image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: ./api
           push: true
@@ -239,7 +240,7 @@ jobs:
           provenance: true
 
       - name: Build and push Client image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: ./client
           push: true
@@ -274,7 +275,7 @@ jobs:
           echo "Deploying ${IMAGE}"
 
       - name: Log in to Azure with OIDC
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: ${{ env.AZURE_NEON_PROOF_CLIENT_ID }}
           tenant-id: ${{ env.AZURE_NEON_PROOF_TENANT_ID }}
@@ -314,7 +315,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Validate smoke suite inventory
         run: |
@@ -336,10 +337,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Docker Compose
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Pull and run full E2E tests
         env:
@@ -360,7 +361,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: full-e2e-test-results
           path: |
@@ -381,7 +382,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Run Trivy repository scan
         uses: aquasecurity/trivy-action@v0.36.0
@@ -412,7 +413,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Run Trivy vulnerability scanner on API
         uses: aquasecurity/trivy-action@v0.36.0

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -20,6 +20,31 @@ jobs:
     name: SonarQube Scan
     runs-on: ubuntu-latest
 
+    services:
+      postgres:
+        image: pgvector/pgvector:pg16
+        env:
+          POSTGRES_USER: bifrost_docs
+          POSTGRES_PASSWORD: testpassword
+          POSTGRES_DB: bifrost_docs_test
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+
+      redis:
+        image: redis:7-alpine
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 6379:6379
+
     permissions:
       contents: read
       pull-requests: read
@@ -38,6 +63,28 @@ jobs:
         if: env.SONAR_TOKEN == ''
         run: |
           echo "SONAR_TOKEN is not configured; skipping SonarQube scan."
+
+      - name: Set up Python for API coverage
+        if: env.SONAR_TOKEN != ''
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+          cache-dependency-path: './api/pyproject.toml'
+
+      - name: Generate API coverage
+        if: env.SONAR_TOKEN != ''
+        working-directory: ./api
+        env:
+          BIFROST_DOCS_SECRET_KEY: test-secret-key-must-be-at-least-32-characters-long
+          BIFROST_DOCS_DATABASE_URL: postgresql+asyncpg://bifrost_docs:testpassword@localhost:5432/bifrost_docs_test
+          BIFROST_DOCS_DATABASE_URL_SYNC: postgresql://bifrost_docs:testpassword@localhost:5432/bifrost_docs_test
+          BIFROST_DOCS_REDIS_URL: redis://localhost:6379/0
+          BIFROST_DOCS_ENVIRONMENT: testing
+        run: |
+          pip install --upgrade pip
+          pip install -e ".[dev]"
+          pytest tests/unit --cov=src --cov-report=xml:coverage.xml --cov-report=term
 
       - name: Set up Python for migration-tool coverage
         if: env.SONAR_TOKEN != ''

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -55,7 +55,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -66,7 +66,7 @@ jobs:
 
       - name: Set up Python for API coverage
         if: env.SONAR_TOKEN != ''
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
           cache: 'pip'
@@ -88,7 +88,7 @@ jobs:
 
       - name: Set up Python for migration-tool coverage
         if: env.SONAR_TOKEN != ''
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
           cache: 'pip'

--- a/.github/workflows/zap-baseline.yml
+++ b/.github/workflows/zap-baseline.yml
@@ -1,0 +1,73 @@
+name: OWASP ZAP Baseline
+
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: Sanctioned Azure proof target to scan
+        required: true
+        default: all
+        type: choice
+        options:
+          - all
+          - frontend
+          - api
+  schedule:
+    - cron: "22 7 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  select-targets:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.targets.outputs.matrix }}
+    steps:
+      - name: Select sanctioned targets
+        id: targets
+        env:
+          TARGET: ${{ github.event.inputs.target || 'all' }}
+        run: |
+          case "${TARGET}" in
+            all)
+              MATRIX='{"include":[{"name":"frontend","url":"https://azure-docs.midtowntg.com"},{"name":"api","url":"https://ca-bifrost-docs-api-neon-dev.icymoss-8e8097f1.eastus.azurecontainerapps.io"}]}'
+              ;;
+            frontend)
+              MATRIX='{"include":[{"name":"frontend","url":"https://azure-docs.midtowntg.com"}]}'
+              ;;
+            api)
+              MATRIX='{"include":[{"name":"api","url":"https://ca-bifrost-docs-api-neon-dev.icymoss-8e8097f1.eastus.azurecontainerapps.io"}]}'
+              ;;
+            *)
+              echo "Unsupported target: ${TARGET}" >&2
+              exit 1
+              ;;
+          esac
+
+          echo "matrix=${MATRIX}" >> "$GITHUB_OUTPUT"
+
+  zap-baseline:
+    name: ZAP baseline (${{ matrix.name }})
+    runs-on: ubuntu-latest
+    needs: select-targets
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.select-targets.outputs.matrix) }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Run OWASP ZAP passive baseline
+        uses: zaproxy/action-baseline@v0.15.0
+        with:
+          target: ${{ matrix.url }}
+          docker_name: ghcr.io/zaproxy/zaproxy:stable
+          allow_issue_writing: false
+          fail_action: false
+          artifact_name: zap-baseline-${{ matrix.name }}
+          cmd_options: >-
+            -m 3
+            -z "-config view.locale=en_GB"
+

--- a/.github/workflows/zap-baseline.yml
+++ b/.github/workflows/zap-baseline.yml
@@ -57,7 +57,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Run OWASP ZAP passive baseline
         uses: zaproxy/action-baseline@v0.15.0

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -44,6 +44,8 @@ dependencies = [
     "boto3>=1.34.0",
     "aiobotocore>=2.13.0",
     "aiohttp>=3.13.4",
+    # Azure Blob Storage
+    "azure-storage-blob>=12.19.0",
     # OpenAI (for embeddings and chat)
     "openai>=1.50.0",
     # Anthropic (for Claude models)

--- a/api/src/config.py
+++ b/api/src/config.py
@@ -171,6 +171,11 @@ class Settings(BaseSettings):
         default="/tmp/bifrost_docs", description="Path to temporary storage directory"
     )
 
+    storage_backend: Literal["s3", "azure_blob"] = Field(
+        default="s3",
+        description="Attachment/export storage backend. Use 'azure_blob' for Azure Storage.",
+    )
+
     # ==========================================================================
     # S3/MinIO Storage
     # ==========================================================================
@@ -210,6 +215,56 @@ class Settings(BaseSettings):
     def s3_configured(self) -> bool:
         """Check if S3 storage is properly configured."""
         return self.s3_access_key is not None and self.s3_secret_key is not None
+
+    # ==========================================================================
+    # Azure Blob Storage
+    # ==========================================================================
+    azure_storage_account_url: str | None = Field(
+        default=None,
+        description="Azure Blob service URL, e.g. https://account.blob.core.windows.net",
+    )
+
+    azure_storage_connection_string: str | None = Field(
+        default=None,
+        description="Azure Storage connection string. Prefer managed identity for production.",
+    )
+
+    azure_storage_account_key: str | None = Field(
+        default=None,
+        description="Azure Storage account key for SAS generation when not using a connection string.",
+    )
+
+    azure_blob_container: str = Field(
+        default="bifrost-docs",
+        description="Azure Blob container name for file storage.",
+    )
+
+    azure_blob_sas_expiry: int = Field(
+        default=600,
+        description="Azure Blob upload SAS expiry in seconds.",
+    )
+
+    azure_blob_download_sas_expiry: int = Field(
+        default=3600,
+        description="Azure Blob download SAS expiry in seconds.",
+    )
+
+    @computed_field
+    @property
+    def azure_blob_configured(self) -> bool:
+        """Check if Azure Blob storage is configured."""
+        return self.azure_storage_connection_string is not None or (
+            self.azure_storage_account_url is not None
+            and self.azure_storage_account_key is not None
+        )
+
+    @computed_field
+    @property
+    def storage_configured(self) -> bool:
+        """Check if the selected storage backend is configured."""
+        if self.storage_backend == "azure_blob":
+            return self.azure_blob_configured
+        return self.s3_configured
 
     # ==========================================================================
     # OpenAI (for embeddings)

--- a/api/src/config.py
+++ b/api/src/config.py
@@ -61,6 +61,10 @@ class Settings(BaseSettings):
     # Redis
     # ==========================================================================
     redis_url: str = Field(default="redis://localhost:6380/0", description="Redis connection URL")
+    rate_limiting_enabled: bool = Field(
+        default=True,
+        description="Enable Redis-backed API rate limiting. Disable for deployments without Redis.",
+    )
 
     # ==========================================================================
     # Security

--- a/api/src/core/rate_limiting.py
+++ b/api/src/core/rate_limiting.py
@@ -10,12 +10,32 @@ Note: If slowapi is not installed, rate limiting is disabled (development mode).
 from collections.abc import Callable
 from typing import Any, cast
 
+from src.config import get_settings
+
+
+class _NoOpLimiter:
+    """Limiter-compatible no-op used when rate limiting is disabled."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        pass
+
+    def limit(self, limits: Any) -> Callable[[Any], Any]:
+        """Return a decorator that leaves the route handler unchanged."""
+
+        def decorator(f: Any) -> Any:
+            return f
+
+        return decorator
+
+    middleware_class: Any = None
+
+
 # Try to import slowapi - if not available, use dummy implementations
 try:
     from slowapi import Limiter as _Limiter  # noqa: F811
     from slowapi.util import get_remote_address as _get_remote_address  # noqa: F811
 
-    RATE_LIMITING_ENABLED = True
+    SLOWAPI_AVAILABLE = True
 
     # Use the real implementations
     class Limiter(_Limiter):  # type: ignore[misc, no-redef]
@@ -28,37 +48,21 @@ try:
         return _get_remote_address(request)  # type: ignore[no-any-return]
 
 except ImportError:
-    RATE_LIMITING_ENABLED = False
+    SLOWAPI_AVAILABLE = False
 
     # Create dummy limiter class and decorator for when slowapi is not installed
-    class Limiter:  # type: ignore[no-redef]
+    class Limiter(_NoOpLimiter):  # type: ignore[no-redef]
         """Dummy Limiter class when slowapi is not installed."""
-
-        def __init__(self, *args: Any, **kwargs: Any) -> None:
-            pass
-
-        def limit(self, limits: Any) -> Callable[[Any], Any]:
-            """Dummy decorator that does nothing when slowapi not installed."""
-
-            def decorator(f: Any) -> Any:
-                return f
-
-            return decorator
-
-        # Dummy middleware_class attribute for type checking
-        middleware_class: Any = None
 
     def get_remote_address(request: Any) -> str:  # type: ignore[misc, no-redef]
         """Dummy get_remote_address when slowapi is not installed."""
         return "127.0.0.1"
 
 
-from src.config import get_settings
-
-# Get Redis URL from settings
 settings = get_settings()
+RATE_LIMITING_ENABLED = SLOWAPI_AVAILABLE and settings.rate_limiting_enabled
 
-# Create limiter with Redis storage (or dummy if slowapi not installed)
+# Create limiter with Redis storage, or a no-op limiter if disabled/unavailable.
 if RATE_LIMITING_ENABLED:
     limiter = Limiter(
         key_func=get_remote_address,
@@ -67,7 +71,7 @@ if RATE_LIMITING_ENABLED:
         default_limits=["100/minute"],  # Default: 100 requests per minute
     )
 else:
-    limiter = Limiter(key_func=get_remote_address)  # Dummy limiter
+    limiter = _NoOpLimiter(key_func=get_remote_address)
 
 
 # Rate limit configurations by endpoint type

--- a/api/src/core/security_headers.py
+++ b/api/src/core/security_headers.py
@@ -23,6 +23,8 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
     - Content-Security-Policy
     - Referrer-Policy
     - Permissions-Policy
+    - Cross-Origin-Resource-Policy
+    - Cache-Control/Pragma/Expires
     """
 
     async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
@@ -40,6 +42,18 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
 
         # Referrer policy
         response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
+
+        # The API is called cross-origin by the Azure Static Web Apps frontend.
+        # Use an explicit CORP value so browsers and scanners do not have to
+        # infer policy from a missing header.
+        response.headers["Cross-Origin-Resource-Policy"] = "cross-origin"
+
+        # API responses can contain documentation, passwords metadata, auth
+        # state, presigned URLs, or other sensitive tenant data. Prefer no-store
+        # by default; static frontend assets are served outside this API.
+        response.headers["Cache-Control"] = "no-cache, no-store, must-revalidate"
+        response.headers["Pragma"] = "no-cache"
+        response.headers["Expires"] = "0"
 
         # Permissions policy (formerly Feature-Policy)
         response.headers["Permissions-Policy"] = (

--- a/api/src/models/contracts/attachment.py
+++ b/api/src/models/contracts/attachment.py
@@ -25,10 +25,10 @@ class AttachmentPublic(BaseModel):
 
     model_config = ConfigDict(from_attributes=True)
 
-    id: str
-    organization_id: str
+    id: UUID | str
+    organization_id: UUID | str
     entity_type: EntityType
-    entity_id: str
+    entity_id: UUID | str
     filename: str
     s3_key: str
     content_type: str

--- a/api/src/models/contracts/base.py
+++ b/api/src/models/contracts/base.py
@@ -27,7 +27,7 @@ class PublicEntityBase(BaseModel):
             username: str | None = None
     """
 
-    model_config = ConfigDict(from_attributes=True)
+    model_config = ConfigDict(from_attributes=True, populate_by_name=True)
 
     id: UUID
     organization_id: UUID
@@ -49,7 +49,7 @@ class PublicOrganizationBase(BaseModel):
     Organization IS the organization, so it doesn't have an organization_id field.
     """
 
-    model_config = ConfigDict(from_attributes=True)
+    model_config = ConfigDict(from_attributes=True, populate_by_name=True)
 
     id: UUID
     name: str

--- a/api/src/models/contracts/configuration.py
+++ b/api/src/models/contracts/configuration.py
@@ -110,8 +110,8 @@ class ConfigurationUpdate(BaseModel):
 class ConfigurationPublic(PublicEntityBase):
     """Configuration public response model."""
 
-    configuration_type_id: str | None = None
-    configuration_status_id: str | None = None
+    configuration_type_id: UUID | str | None = None
+    configuration_status_id: UUID | str | None = None
     name: str
     serial_number: str | None = None
     asset_tag: str | None = None

--- a/api/src/routers/attachments.py
+++ b/api/src/routers/attachments.py
@@ -135,7 +135,7 @@ async def create_attachment(
         Attachment ID and presigned upload URL
     """
     settings = get_settings()
-    if not settings.s3_configured:
+    if not settings.storage_configured:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="File storage is not configured",
@@ -249,7 +249,7 @@ async def download_attachment(
         Presigned download URL and file metadata
     """
     settings = get_settings()
-    if not settings.s3_configured:
+    if not settings.storage_configured:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="File storage is not configured",
@@ -302,7 +302,7 @@ async def view_attachment(
         302 redirect to presigned download URL
     """
     settings = get_settings()
-    if not settings.s3_configured:
+    if not settings.storage_configured:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="File storage is not configured",
@@ -358,7 +358,7 @@ async def delete_attachment(
 
     # Then delete from S3 (best effort)
     settings = get_settings()
-    if settings.s3_configured:
+    if settings.storage_configured:
         file_storage = get_file_storage_service()
         await file_storage.delete_file(s3_key)
 
@@ -399,7 +399,7 @@ async def upload_document_image(
         Upload URL and image URL for markdown
     """
     settings = get_settings()
-    if not settings.s3_configured:
+    if not settings.storage_configured:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="File storage is not configured",

--- a/api/src/services/file_storage.py
+++ b/api/src/services/file_storage.py
@@ -1,13 +1,13 @@
 """
-S3 storage service for file attachments.
+File storage service for attachments and exports.
 
-Handles S3 operations including:
-- Presigned upload URLs
-- Presigned download URLs
+Handles object storage operations including:
+- Presigned/SAS upload URLs
+- Presigned/SAS download URLs
 - File deletion
 - MIME type detection
 
-Supports MinIO in development and any S3-compatible storage in production.
+Supports S3-compatible storage and Azure Blob Storage.
 """
 
 import hashlib
@@ -15,6 +15,7 @@ import logging
 import mimetypes
 from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING, Any
+from urllib.parse import parse_qsl
 from uuid import UUID
 
 from src.config import Settings, get_settings
@@ -26,17 +27,18 @@ logger = logging.getLogger(__name__)
 
 
 class FileStorageService:
-    """Service for S3-compatible file storage operations."""
+    """Service for object storage operations."""
 
     def __init__(self, settings: Settings | None = None):
         """
         Initialize file storage service.
 
         Args:
-            settings: Application settings with S3 configuration.
+            settings: Application settings with storage configuration.
                      Uses get_settings() if not provided.
         """
         self.settings = settings or get_settings()
+        self.backend = getattr(self.settings, "storage_backend", "s3")
 
     @asynccontextmanager
     async def get_client(self) -> "AsyncGenerator[Any, None]":
@@ -66,6 +68,91 @@ class FileStorageService:
             region_name=self.settings.s3_region,
         ) as client:
             yield client
+
+    def _require_azure_blob_configured(self) -> None:
+        if not self.settings.azure_blob_configured:
+            raise RuntimeError(
+                "Azure Blob storage not configured. Set BIFROST_DOCS_AZURE_STORAGE_CONNECTION_STRING "
+                "or BIFROST_DOCS_AZURE_STORAGE_ACCOUNT_URL and BIFROST_DOCS_AZURE_STORAGE_ACCOUNT_KEY."
+            )
+
+    def _get_blob_service_client(self) -> Any:
+        """Create an Azure Blob service client from configured credentials."""
+        self._require_azure_blob_configured()
+
+        from azure.storage.blob import BlobServiceClient
+
+        if self.settings.azure_storage_connection_string:
+            return BlobServiceClient.from_connection_string(
+                self.settings.azure_storage_connection_string
+            )
+
+        if not self.settings.azure_storage_account_url:
+            raise RuntimeError("Azure Blob storage account URL is required")
+
+        return BlobServiceClient(
+            account_url=self.settings.azure_storage_account_url,
+            credential=self.settings.azure_storage_account_key,
+        )
+
+    def _get_azure_account_name_and_key(self) -> tuple[str, str]:
+        """Get the Azure Storage account name and key for SAS generation."""
+        if self.settings.azure_storage_connection_string:
+            parts = dict(parse_qsl(self.settings.azure_storage_connection_string.replace(";", "&")))
+            account_name = parts.get("AccountName")
+            account_key = parts.get("AccountKey")
+            if account_name and account_key:
+                return account_name, account_key
+
+        if self.settings.azure_storage_account_url and self.settings.azure_storage_account_key:
+            account_name = self.settings.azure_storage_account_url.removeprefix("https://").split(
+                ".", 1
+            )[0]
+            return account_name, self.settings.azure_storage_account_key
+
+        raise RuntimeError("Azure Blob SAS generation requires a storage account key")
+
+    def _generate_blob_sas_url(
+        self,
+        blob_name: str,
+        expires_in: int,
+        permission: str,
+        content_type: str | None = None,
+        filename: str | None = None,
+    ) -> str:
+        """Generate an Azure Blob SAS URL for direct browser access."""
+        self._require_azure_blob_configured()
+
+        from datetime import UTC, datetime, timedelta
+
+        from azure.storage.blob import BlobSasPermissions, generate_blob_sas
+
+        service = self._get_blob_service_client()
+        account_name, account_key = self._get_azure_account_name_and_key()
+        container_name = self.settings.azure_blob_container
+        blob_client = service.get_blob_client(container=container_name, blob=blob_name)
+
+        permissions = BlobSasPermissions(
+            read="r" in permission,
+            write="w" in permission,
+            create="w" in permission,
+        )
+        kwargs: dict[str, Any] = {
+            "account_name": account_name,
+            "container_name": container_name,
+            "blob_name": blob_name,
+            "permission": permissions,
+            "expiry": datetime.now(UTC) + timedelta(seconds=expires_in),
+            "account_key": account_key,
+        }
+
+        if content_type:
+            kwargs["content_type"] = content_type
+        if filename:
+            kwargs["content_disposition"] = f'attachment; filename="{filename}"'
+
+        sas_token = generate_blob_sas(**kwargs)
+        return f"{blob_client.url}?{sas_token}"
 
     @staticmethod
     def compute_hash(content: bytes) -> str:
@@ -155,6 +242,16 @@ class FileStorageService:
         Returns:
             Presigned PUT URL for direct browser upload
         """
+        if self.backend == "azure_blob":
+            if expires_in is None:
+                expires_in = self.settings.azure_blob_sas_expiry
+            return self._generate_blob_sas_url(
+                s3_key,
+                expires_in=expires_in,
+                permission="w",
+                content_type=content_type,
+            )
+
         if expires_in is None:
             expires_in = self.settings.s3_presigned_url_expiry
 
@@ -187,6 +284,16 @@ class FileStorageService:
         Returns:
             Presigned GET URL for download
         """
+        if self.backend == "azure_blob":
+            if expires_in is None:
+                expires_in = self.settings.azure_blob_download_sas_expiry
+            return self._generate_blob_sas_url(
+                s3_key,
+                expires_in=expires_in,
+                permission="r",
+                filename=filename,
+            )
+
         if expires_in is None:
             expires_in = self.settings.s3_download_url_expiry
 
@@ -218,6 +325,16 @@ class FileStorageService:
             True if deletion was successful
         """
         try:
+            if self.backend == "azure_blob":
+                service = self._get_blob_service_client()
+                blob = service.get_blob_client(
+                    container=self.settings.azure_blob_container,
+                    blob=s3_key,
+                )
+                blob.delete_blob(delete_snapshots="include")
+                logger.info(f"Deleted file from Azure Blob: {s3_key}")
+                return True
+
             async with self.get_client() as s3:
                 await s3.delete_object(
                     Bucket=self.settings.s3_bucket,
@@ -247,6 +364,22 @@ class FileStorageService:
             True if upload was successful
         """
         try:
+            if self.backend == "azure_blob":
+                service = self._get_blob_service_client()
+                blob = service.get_blob_client(
+                    container=self.settings.azure_blob_container,
+                    blob=s3_key,
+                )
+                from azure.storage.blob import ContentSettings
+
+                blob.upload_blob(
+                    content,
+                    overwrite=True,
+                    content_settings=ContentSettings(content_type=content_type),
+                )
+                logger.info(f"Uploaded file to Azure Blob: {s3_key} ({len(content)} bytes)")
+                return True
+
             async with self.get_client() as s3:
                 await s3.put_object(
                     Bucket=self.settings.s3_bucket,
@@ -271,6 +404,14 @@ class FileStorageService:
             True if file exists
         """
         try:
+            if self.backend == "azure_blob":
+                service = self._get_blob_service_client()
+                blob = service.get_blob_client(
+                    container=self.settings.azure_blob_container,
+                    blob=s3_key,
+                )
+                return blob.exists()
+
             async with self.get_client() as s3:
                 await s3.head_object(
                     Bucket=self.settings.s3_bucket,
@@ -290,6 +431,16 @@ class FileStorageService:
             True if bucket exists or was created successfully
         """
         try:
+            if self.backend == "azure_blob":
+                service = self._get_blob_service_client()
+                container = service.get_container_client(self.settings.azure_blob_container)
+                if not container.exists():
+                    container.create_container()
+                    logger.info(
+                        f"Created Azure Blob container: {self.settings.azure_blob_container}"
+                    )
+                return True
+
             async with self.get_client() as s3:
                 try:
                     await s3.head_bucket(Bucket=self.settings.s3_bucket)

--- a/api/tests/unit/test_file_storage.py
+++ b/api/tests/unit/test_file_storage.py
@@ -33,6 +33,15 @@ def mock_settings():
     settings.s3_bucket = "test-bucket"
     settings.s3_presigned_url_expiry = 600
     settings.s3_download_url_expiry = 3600
+    settings.storage_backend = "s3"
+    settings.storage_configured = True
+    settings.azure_blob_configured = False
+    settings.azure_storage_connection_string = None
+    settings.azure_storage_account_url = None
+    settings.azure_storage_account_key = None
+    settings.azure_blob_container = "test-container"
+    settings.azure_blob_sas_expiry = 600
+    settings.azure_blob_download_sas_expiry = 3600
     return settings
 
 
@@ -294,3 +303,145 @@ class TestFileStorageServiceNotConfigured:
         with pytest.raises(RuntimeError, match="S3 storage not configured"):
             async with service.get_client():
                 pass
+
+
+@pytest.fixture
+def mock_azure_settings():
+    """Create mock Azure Blob settings for testing."""
+    settings = MagicMock()
+    settings.storage_backend = "azure_blob"
+    settings.storage_configured = True
+    settings.s3_configured = False
+    settings.azure_blob_configured = True
+    settings.azure_storage_connection_string = (
+        "DefaultEndpointsProtocol=https;"
+        "AccountName=testaccount;"
+        "AccountKey=testkey;"
+        "EndpointSuffix=core.windows.net"
+    )
+    settings.azure_storage_account_url = None
+    settings.azure_storage_account_key = None
+    settings.azure_blob_container = "test-container"
+    settings.azure_blob_sas_expiry = 600
+    settings.azure_blob_download_sas_expiry = 3600
+    return settings
+
+
+@pytest.fixture
+def azure_storage_service(mock_azure_settings):
+    """Create Azure Blob file storage service with mock settings."""
+    return FileStorageService(settings=mock_azure_settings)
+
+
+class TestAzureBlobFileStorageService:
+    """Tests for Azure Blob storage backend."""
+
+    def test_azure_account_name_and_key_from_connection_string(self, azure_storage_service):
+        """Test Azure account credentials are parsed from connection string."""
+        account_name, account_key = azure_storage_service._get_azure_account_name_and_key()
+
+        assert account_name == "testaccount"
+        assert account_key == "testkey"
+
+    def test_azure_account_name_and_key_from_account_url(self, mock_azure_settings):
+        """Test Azure account credentials are parsed from account URL and key."""
+        mock_azure_settings.azure_storage_connection_string = None
+        mock_azure_settings.azure_storage_account_url = "https://docsproof.blob.core.windows.net"
+        mock_azure_settings.azure_storage_account_key = "account-key"
+        service = FileStorageService(settings=mock_azure_settings)
+
+        account_name, account_key = service._get_azure_account_name_and_key()
+
+        assert account_name == "docsproof"
+        assert account_key == "account-key"
+
+    @pytest.mark.asyncio
+    async def test_generate_azure_upload_url(self, azure_storage_service):
+        """Test Azure Blob upload SAS URL generation."""
+        mock_blob = MagicMock()
+        mock_blob.url = "https://testaccount.blob.core.windows.net/test-container/test/key.pdf"
+        mock_service = MagicMock()
+        mock_service.get_blob_client.return_value = mock_blob
+
+        with (
+            patch.object(
+                azure_storage_service, "_get_blob_service_client", return_value=mock_service
+            ),
+            patch("azure.storage.blob.generate_blob_sas", return_value="sig=token") as mock_sas,
+        ):
+            url = await azure_storage_service.generate_upload_url(
+                s3_key="test/key.pdf",
+                content_type="application/pdf",
+            )
+
+        assert (
+            url == "https://testaccount.blob.core.windows.net/test-container/test/key.pdf?sig=token"
+        )
+        mock_service.get_blob_client.assert_called_once_with(
+            container="test-container",
+            blob="test/key.pdf",
+        )
+        sas_kwargs = mock_sas.call_args.kwargs
+        assert sas_kwargs["account_name"] == "testaccount"
+        assert sas_kwargs["container_name"] == "test-container"
+        assert sas_kwargs["blob_name"] == "test/key.pdf"
+        assert sas_kwargs["account_key"] == "testkey"
+        assert sas_kwargs["content_type"] == "application/pdf"
+        assert sas_kwargs["permission"].write is True
+        assert sas_kwargs["permission"].create is True
+
+    @pytest.mark.asyncio
+    async def test_generate_azure_download_url_with_filename(self, azure_storage_service):
+        """Test Azure Blob download SAS URL generation."""
+        mock_blob = MagicMock()
+        mock_blob.url = "https://testaccount.blob.core.windows.net/test-container/test/key.pdf"
+        mock_service = MagicMock()
+        mock_service.get_blob_client.return_value = mock_blob
+
+        with (
+            patch.object(
+                azure_storage_service, "_get_blob_service_client", return_value=mock_service
+            ),
+            patch("azure.storage.blob.generate_blob_sas", return_value="sig=token") as mock_sas,
+        ):
+            url = await azure_storage_service.generate_download_url(
+                s3_key="test/key.pdf",
+                filename="document.pdf",
+            )
+
+        assert (
+            url == "https://testaccount.blob.core.windows.net/test-container/test/key.pdf?sig=token"
+        )
+        sas_kwargs = mock_sas.call_args.kwargs
+        assert sas_kwargs["permission"].read is True
+        assert sas_kwargs["content_disposition"] == 'attachment; filename="document.pdf"'
+
+    @pytest.mark.asyncio
+    async def test_azure_delete_file(self, azure_storage_service):
+        """Test Azure Blob deletion."""
+        mock_blob = MagicMock()
+        mock_service = MagicMock()
+        mock_service.get_blob_client.return_value = mock_blob
+
+        with patch.object(
+            azure_storage_service, "_get_blob_service_client", return_value=mock_service
+        ):
+            result = await azure_storage_service.delete_file("test/key.pdf")
+
+        assert result is True
+        mock_blob.delete_blob.assert_called_once_with(delete_snapshots="include")
+
+    @pytest.mark.asyncio
+    async def test_azure_file_exists(self, azure_storage_service):
+        """Test Azure Blob existence check."""
+        mock_blob = MagicMock()
+        mock_blob.exists.return_value = True
+        mock_service = MagicMock()
+        mock_service.get_blob_client.return_value = mock_blob
+
+        with patch.object(
+            azure_storage_service, "_get_blob_service_client", return_value=mock_service
+        ):
+            result = await azure_storage_service.file_exists("test/key.pdf")
+
+        assert result is True

--- a/api/tests/unit/test_file_storage.py
+++ b/api/tests/unit/test_file_storage.py
@@ -445,3 +445,68 @@ class TestAzureBlobFileStorageService:
             result = await azure_storage_service.file_exists("test/key.pdf")
 
         assert result is True
+
+    @pytest.mark.asyncio
+    async def test_azure_upload_file(self, azure_storage_service):
+        """Test Azure Blob upload."""
+        mock_blob = MagicMock()
+        mock_service = MagicMock()
+        mock_service.get_blob_client.return_value = mock_blob
+
+        with (
+            patch.object(
+                azure_storage_service, "_get_blob_service_client", return_value=mock_service
+            ),
+            patch("azure.storage.blob.ContentSettings") as mock_content_settings,
+        ):
+            result = await azure_storage_service.upload_file(
+                s3_key="test/key.pdf",
+                content=b"file-content",
+                content_type="application/pdf",
+            )
+
+        assert result is True
+        mock_content_settings.assert_called_once_with(content_type="application/pdf")
+        mock_blob.upload_blob.assert_called_once_with(
+            b"file-content",
+            overwrite=True,
+            content_settings=mock_content_settings.return_value,
+        )
+
+    @pytest.mark.asyncio
+    async def test_azure_ensure_container_exists_creates_missing_container(
+        self,
+        azure_storage_service,
+    ):
+        """Test Azure Blob container creation."""
+        mock_container = MagicMock()
+        mock_container.exists.return_value = False
+        mock_service = MagicMock()
+        mock_service.get_container_client.return_value = mock_container
+
+        with patch.object(
+            azure_storage_service, "_get_blob_service_client", return_value=mock_service
+        ):
+            result = await azure_storage_service.ensure_bucket_exists()
+
+        assert result is True
+        mock_service.get_container_client.assert_called_once_with("test-container")
+        mock_container.create_container.assert_called_once()
+
+    def test_azure_blob_configuration_required(self, mock_azure_settings):
+        """Test Azure Blob operations require complete configuration."""
+        mock_azure_settings.azure_blob_configured = False
+        service = FileStorageService(settings=mock_azure_settings)
+
+        with pytest.raises(RuntimeError, match="Azure Blob storage not configured"):
+            service._require_azure_blob_configured()
+
+    def test_azure_sas_generation_requires_account_key(self, mock_azure_settings):
+        """Test SAS generation requires account key material."""
+        mock_azure_settings.azure_storage_connection_string = None
+        mock_azure_settings.azure_storage_account_url = None
+        mock_azure_settings.azure_storage_account_key = None
+        service = FileStorageService(settings=mock_azure_settings)
+
+        with pytest.raises(RuntimeError, match="Azure Blob SAS generation requires"):
+            service._get_azure_account_name_and_key()

--- a/api/tests/unit/test_security_headers.py
+++ b/api/tests/unit/test_security_headers.py
@@ -62,6 +62,20 @@ class TestSecurityHeadersMiddleware:
         assert response.status_code == 200
         assert response.headers["Referrer-Policy"] == "strict-origin-when-cross-origin"
 
+    def test_cross_origin_resource_policy_header(self, client):
+        """Test Cross-Origin-Resource-Policy is set for the API boundary."""
+        response = client.get("/test")
+        assert response.status_code == 200
+        assert response.headers["Cross-Origin-Resource-Policy"] == "cross-origin"
+
+    def test_cache_headers_prevent_storing_api_responses(self, client):
+        """Test API responses are not stored by shared or browser caches."""
+        response = client.get("/test")
+        assert response.status_code == 200
+        assert response.headers["Cache-Control"] == "no-cache, no-store, must-revalidate"
+        assert response.headers["Pragma"] == "no-cache"
+        assert response.headers["Expires"] == "0"
+
     def test_permissions_policy_header(self, client):
         """Test Permissions-Policy header is set with safe defaults."""
         response = client.get("/test")
@@ -106,6 +120,10 @@ class TestSecurityHeadersMiddleware:
             "X-Frame-Options",
             "X-XSS-Protection",
             "Referrer-Policy",
+            "Cross-Origin-Resource-Policy",
+            "Cache-Control",
+            "Pragma",
+            "Expires",
             "Permissions-Policy",
             "Content-Security-Policy",
         ]

--- a/api/tests/unit/test_storage_and_rate_config.py
+++ b/api/tests/unit/test_storage_and_rate_config.py
@@ -1,0 +1,61 @@
+"""Tests for storage backend and rate-limiting configuration."""
+
+import importlib
+
+from src.config import Settings
+
+
+def test_storage_configured_uses_s3_backend_by_default():
+    settings = Settings(secret_key="x" * 32, s3_access_key="key", s3_secret_key="secret")
+
+    assert settings.storage_backend == "s3"
+    assert settings.s3_configured is True
+    assert settings.storage_configured is True
+
+
+def test_storage_configured_uses_azure_blob_backend():
+    settings = Settings(
+        secret_key="x" * 32,
+        storage_backend="azure_blob",
+        azure_storage_account_url="https://docsproof.blob.core.windows.net",
+        azure_storage_account_key="account-key",
+    )
+
+    assert settings.azure_blob_configured is True
+    assert settings.storage_configured is True
+
+
+def test_storage_configured_is_false_for_incomplete_azure_blob_backend():
+    settings = Settings(
+        secret_key="x" * 32,
+        storage_backend="azure_blob",
+        azure_storage_account_url="https://docsproof.blob.core.windows.net",
+    )
+
+    assert settings.azure_blob_configured is False
+    assert settings.storage_configured is False
+
+
+def test_rate_limiting_can_be_disabled(monkeypatch):
+    monkeypatch.setenv("BIFROST_DOCS_SECRET_KEY", "x" * 32)
+    monkeypatch.setenv("BIFROST_DOCS_RATE_LIMITING_ENABLED", "false")
+
+    import src.config as config
+    import src.core.rate_limiting as rate_limiting
+
+    config.clear_settings_cache()
+    reloaded = importlib.reload(rate_limiting)
+
+    assert reloaded.RATE_LIMITING_ENABLED is False
+    assert reloaded.limiter.middleware_class is None
+
+
+def test_noop_limiter_decorator_returns_original_function():
+    import src.core.rate_limiting as rate_limiting
+
+    limiter = rate_limiting._NoOpLimiter()
+
+    def endpoint():
+        return "ok"
+
+    assert limiter.limit("1/minute")(endpoint) is endpoint

--- a/client/public/staticwebapp.config.json
+++ b/client/public/staticwebapp.config.json
@@ -1,0 +1,34 @@
+{
+  "auth": {
+    "identityProviders": {
+      "azureActiveDirectory": {
+        "registration": {
+          "openIdIssuer": "https://login.microsoftonline.com/a3599b15-c39c-4b41-a219-7e24dd5b5190/v2.0",
+          "clientIdSettingName": "AZURE_CLIENT_ID",
+          "clientSecretSettingName": "AZURE_CLIENT_SECRET"
+        }
+      }
+    }
+  },
+  "routes": [
+    {
+      "route": "/*",
+      "allowedRoles": [
+        "authenticated"
+      ]
+    }
+  ],
+  "responseOverrides": {
+    "401": {
+      "statusCode": 302,
+      "redirect": "/.auth/login/aad"
+    }
+  },
+  "navigationFallback": {
+    "rewrite": "/index.html",
+    "exclude": [
+      "/assets/*",
+      "/*.{css,scss,js,png,gif,ico,jpg,svg,woff,woff2,ttf,eot,json}"
+    ]
+  }
+}

--- a/client/public/staticwebapp.config.json
+++ b/client/public/staticwebapp.config.json
@@ -12,6 +12,13 @@
   },
   "routes": [
     {
+      "route": "/.auth/*",
+      "allowedRoles": [
+        "anonymous",
+        "authenticated"
+      ]
+    },
+    {
       "route": "/*",
       "allowedRoles": [
         "authenticated"

--- a/docs/deployment/AZURE-NEON-PROOF.md
+++ b/docs/deployment/AZURE-NEON-PROOF.md
@@ -1,0 +1,131 @@
+# Azure + Neon Proof Deployment
+
+This runbook stands up Bifrost Docs with Azure hosting the app/platform services and Neon hosting Postgres.
+
+## Architecture
+
+- Azure Resource Group: `rg-bifrost-docs-neon-dev`
+- Azure Container Apps: FastAPI API from the pinned GHCR image
+- Azure Container Apps Job: one-shot `scripts.init_container` migrations/default setup
+- Azure Storage:
+  - Static website hosting for the React build
+  - Private `attachments` container for attachment/export blobs
+  - Private `backups` container for DB exports
+- Azure Key Vault: proof secrets copied at deployment time
+- Log Analytics + Application Insights: API logs and basic telemetry
+- Neon Free: Postgres with `pgvector`
+
+The first proof intentionally defers Redis-backed ARQ workers and WebSocket fanout. Text search and core CRUD flows can be validated first; semantic indexing can be enabled after the core Azure/Neon path is healthy.
+
+## Prerequisites
+
+- Azure CLI authenticated to the Azure Sponsorship subscription.
+- Neon project created with a database/user for Bifrost Docs.
+- Neon direct/sync connection string: `postgresql://...`
+- Neon async connection string: `postgresql+asyncpg://...`
+- PostgreSQL client tools available locally if restoring a dump from this workstation.
+- Latest CI image available in GHCR, for example `ghcr.io/mtg-thomas/bifrost-docs-api:<short-sha>`.
+
+Enable pgvector in Neon:
+
+```sql
+CREATE EXTENSION IF NOT EXISTS vector;
+```
+
+## Export The Current Dev VM Database
+
+```powershell
+.\scripts\export-dev-vm-db.ps1
+```
+
+The script writes a custom-format dump and row-count stats under:
+
+```text
+.migration-runs/azure-neon-proof/<timestamp>/
+```
+
+The current dev VM DB was measured at about 15 MB, so it fits comfortably in Neon Free.
+
+## Restore Into Neon
+
+```powershell
+.\scripts\restore-neon-db.ps1 `
+  -DumpPath ".migration-runs\azure-neon-proof\<timestamp>\bifrost-docs-dev.dump" `
+  -DatabaseUrlSync "postgresql://USER:PASSWORD@HOST/DB?sslmode=require"
+```
+
+After restore, run the same smoke SQL against Neon:
+
+```sql
+SELECT pg_size_pretty(pg_database_size(current_database())) AS database_size;
+SELECT 'organizations' AS table_name, COUNT(*) AS row_count FROM organizations
+UNION ALL SELECT 'documents', COUNT(*) FROM documents
+UNION ALL SELECT 'attachments', COUNT(*) FROM attachments
+UNION ALL SELECT 'passwords', COUNT(*) FROM passwords
+UNION ALL SELECT 'relationships', COUNT(*) FROM relationships
+UNION ALL SELECT 'embedding_index', COUNT(*) FROM embedding_index
+ORDER BY table_name;
+```
+
+## Deploy Azure Proof Resources
+
+```powershell
+.\scripts\deploy-azure-neon-proof.ps1 `
+  -SubscriptionName "Azure Sponsorship" `
+  -ResourceGroupName "rg-bifrost-docs-neon-dev" `
+  -Location "eastus" `
+  -EnvironmentName "neon-dev" `
+  -ApiImage "ghcr.io/mtg-thomas/bifrost-docs-api:<short-sha>" `
+  -DatabaseUrl "postgresql+asyncpg://USER:PASSWORD@HOST/DB?ssl=require" `
+  -DatabaseUrlSync "postgresql://USER:PASSWORD@HOST/DB?sslmode=require"
+```
+
+The script:
+
+- creates/updates the Azure resource group;
+- deploys `infra/azure-neon/main.bicep`;
+- runs the Container Apps migration/init job;
+- builds the frontend with `VITE_API_URL` set to the API URL;
+- uploads `client/dist` to Azure Storage static website hosting;
+- updates API CORS and WebAuthn origin to the static website URL.
+
+## Runtime Configuration
+
+The API uses:
+
+- `BIFROST_DOCS_STORAGE_BACKEND=azure_blob`
+- `BIFROST_DOCS_AZURE_STORAGE_ACCOUNT_URL=<storage blob endpoint>`
+- `BIFROST_DOCS_AZURE_STORAGE_ACCOUNT_KEY=<generated account key>`
+- `BIFROST_DOCS_AZURE_BLOB_CONTAINER=attachments`
+
+The attachment table and API contracts still use the existing `s3_key` field name. Treat it as an object key, not as proof the backing store is S3.
+
+## Validation
+
+Check API health:
+
+```powershell
+Invoke-RestMethod "https://<api-fqdn>/health"
+```
+
+Then validate from the browser:
+
+- login/setup works;
+- organizations load;
+- documents load;
+- passwords/configurations pages load;
+- attachment upload/download works against Azure Blob;
+- text search works.
+
+Optional semantic search validation:
+
+- configure an embeddings API key;
+- run reindex;
+- verify `embedding_index` row count and size remain below the expected proof envelope.
+
+## Known Proof Limits
+
+- The ARQ worker and Redis pub/sub path are not converted in this first slice.
+- WebSocket/reindex progress may need a later Azure Web PubSub or polling pass.
+- Neon Free is appropriate for proof/staging, not production cutover.
+- The API uses an Azure Storage account key for SAS generation in this proof. Managed identity/user delegation SAS can replace this later.

--- a/docs/deployment/AZURE-NEON-PROOF.md
+++ b/docs/deployment/AZURE-NEON-PROOF.md
@@ -100,6 +100,26 @@ The API uses:
 
 The attachment table and API contracts still use the existing `s3_key` field name. Treat it as an object key, not as proof the backing store is S3.
 
+## GitHub Actions Proof Deploy
+
+Manual `CI - Test & Build` workflow runs build and push the GHCR images, deploy the proof Static Web Apps frontend, and update the Azure Container Apps API to the same short-SHA image tag.
+
+The API deploy uses GitHub Actions OIDC instead of a stored Azure client secret. The Entra app registration must have a federated credential with:
+
+```json
+{
+  "issuer": "https://token.actions.githubusercontent.com",
+  "subject": "repo:MTG-Thomas/bifrost-docs:environment:azure-neon-proof",
+  "audiences": ["api://AzureADTokenExchange"]
+}
+```
+
+The app also needs permission to update:
+
+```text
+/subscriptions/a1d63b24-1202-4bfa-9086-cf32d1d352fc/resourceGroups/rg-bifrost-docs-neon-dev/providers/Microsoft.App/containerApps/ca-bifrost-docs-api-neon-dev
+```
+
 ## Validation
 
 Check API health:

--- a/docs/security/ZAP-BASELINE.md
+++ b/docs/security/ZAP-BASELINE.md
@@ -1,0 +1,41 @@
+# OWASP ZAP Baseline Scanning
+
+Bifrost Docs uses a sanctioned OWASP ZAP baseline workflow for passive DAST coverage of the Azure + Neon proof deployment.
+
+## Scope
+
+The workflow is intentionally limited to known Midtown-owned proof endpoints:
+
+- Frontend: `https://azure-docs.midtowntg.com`
+- API: `https://ca-bifrost-docs-api-neon-dev.icymoss-8e8097f1.eastus.azurecontainerapps.io`
+
+The workflow does not accept arbitrary URLs. Add new targets in code review so scan scope stays explicit.
+
+## What It Runs
+
+The workflow uses `zaproxy/action-baseline` with the stable ZAP container. This runs the ZAP spider briefly and waits for passive scanning to complete. It is intended for CI and staging-style systems because it does not run active attack payloads.
+
+Current settings:
+
+- manual `workflow_dispatch` target selection: `all`, `frontend`, or `api`;
+- weekly scheduled scan on Monday morning UTC;
+- passive baseline only;
+- no GitHub issue auto-writing;
+- reports uploaded as workflow artifacts;
+- `fail_action: false` while the first findings are triaged.
+
+## Operating Notes
+
+- Treat this as perimeter and unauthenticated coverage first. The Entra-protected frontend and API auth boundary are part of what we want to inspect.
+- Do not enable active scans against the proof environment until we have a seeded throwaway organization, a low-privilege test user, and a cleanup/reset path.
+- Do not scan customer production domains or third-party systems from this workflow.
+- Do not put bearer tokens, cookies, passwords, or TOTP secrets into workflow logs.
+- Review reports after each run and convert real findings into tracked remediation work.
+
+## Next Hardening Steps
+
+1. Review the first baseline artifacts and classify findings into true positives, accepted proof limits, and false positives.
+2. Add a small ZAP rules file only after triage, keeping each ignore documented.
+3. Add authenticated coverage with a disposable user and seeded proof data.
+4. Consider a separate active-scan workflow gated by an environment approval and pointed only at resettable test data.
+

--- a/infra/azure-neon/main.bicep
+++ b/infra/azure-neon/main.bicep
@@ -1,0 +1,401 @@
+@description('Azure region for Bifrost Docs proof resources.')
+param location string = resourceGroup().location
+
+@description('Short environment name used in resource names.')
+param environmentName string = 'neon-dev'
+
+@description('Pinned API image published by CI, e.g. ghcr.io/mtg-thomas/bifrost-docs-api:abcdef1.')
+param apiImage string
+
+@description('Optional Azure Container Registry login server, e.g. myregistry.azurecr.io.')
+param acrLoginServer string = ''
+
+@description('Optional Azure Container Registry name. When set, the API Container App gets AcrPull via managed identity.')
+param acrName string = ''
+
+@description('Container App external API hostname CORS origin, e.g. https://docs-proof.example.com. Use the generated hostname until custom DNS exists.')
+param corsOrigins string
+
+@description('WebAuthn RP ID for the proof hostname.')
+param webauthnRpId string
+
+@description('WebAuthn origin URL for the proof hostname.')
+param webauthnOrigin string
+
+@secure()
+@description('Bifrost Docs JWT/encryption secret.')
+param bifrostDocsSecretKey string
+
+@secure()
+@description('Neon async SQLAlchemy URL, postgresql+asyncpg://...')
+param databaseUrl string
+
+@secure()
+@description('Neon sync SQLAlchemy URL, postgresql://...')
+param databaseUrlSync string
+
+@description('Minimum API replicas. Use 0 for the lowest-cost proof.')
+param apiMinReplicas int = 0
+
+@description('Maximum API replicas.')
+param apiMaxReplicas int = 2
+
+var normalizedEnvironment = toLower(replace(environmentName, '-', ''))
+var suffix = uniqueString(resourceGroup().id, environmentName)
+var storageName = take('bifdocs${normalizedEnvironment}${suffix}', 24)
+var logName = 'log-bifrost-docs-${environmentName}'
+var appInsightsName = 'appi-bifrost-docs-${environmentName}'
+var containerEnvName = 'cae-bifrost-docs-${environmentName}'
+var apiName = 'ca-bifrost-docs-api-${environmentName}'
+var initJobName = 'caj-bifrost-docs-init-${environmentName}'
+var keyVaultName = take('kv-bifdocs-${normalizedEnvironment}-${suffix}', 24)
+var attachmentsContainerName = 'attachments'
+var backupsContainerName = 'backups'
+
+resource acr 'Microsoft.ContainerRegistry/registries@2023-07-01' existing = if (!empty(acrName)) {
+  name: acrName
+}
+
+resource logAnalytics 'Microsoft.OperationalInsights/workspaces@2023-09-01' = {
+  name: logName
+  location: location
+  properties: {
+    sku: {
+      name: 'PerGB2018'
+    }
+    retentionInDays: 30
+  }
+}
+
+resource appInsights 'Microsoft.Insights/components@2020-02-02' = {
+  name: appInsightsName
+  location: location
+  kind: 'web'
+  properties: {
+    Application_Type: 'web'
+    WorkspaceResourceId: logAnalytics.id
+  }
+}
+
+resource storage 'Microsoft.Storage/storageAccounts@2023-05-01' = {
+  name: storageName
+  location: location
+  sku: {
+    name: 'Standard_LRS'
+  }
+  kind: 'StorageV2'
+  properties: {
+    allowBlobPublicAccess: false
+    minimumTlsVersion: 'TLS1_2'
+    supportsHttpsTrafficOnly: true
+  }
+}
+
+resource blobService 'Microsoft.Storage/storageAccounts/blobServices@2023-05-01' = {
+  parent: storage
+  name: 'default'
+}
+
+resource attachments 'Microsoft.Storage/storageAccounts/blobServices/containers@2023-05-01' = {
+  parent: blobService
+  name: attachmentsContainerName
+  properties: {
+    publicAccess: 'None'
+  }
+}
+
+resource backups 'Microsoft.Storage/storageAccounts/blobServices/containers@2023-05-01' = {
+  parent: blobService
+  name: backupsContainerName
+  properties: {
+    publicAccess: 'None'
+  }
+}
+
+resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' = {
+  name: keyVaultName
+  location: location
+  properties: {
+    tenantId: tenant().tenantId
+    sku: {
+      family: 'A'
+      name: 'standard'
+    }
+    enableRbacAuthorization: true
+    enablePurgeProtection: false
+    enabledForTemplateDeployment: true
+    publicNetworkAccess: 'Enabled'
+  }
+}
+
+resource secretBifrostKey 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
+  parent: keyVault
+  name: 'bifrost-docs-secret-key'
+  properties: {
+    value: bifrostDocsSecretKey
+  }
+}
+
+resource secretDatabaseUrl 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
+  parent: keyVault
+  name: 'database-url'
+  properties: {
+    value: databaseUrl
+  }
+}
+
+resource secretDatabaseUrlSync 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
+  parent: keyVault
+  name: 'database-url-sync'
+  properties: {
+    value: databaseUrlSync
+  }
+}
+
+resource secretStorageKey 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
+  parent: keyVault
+  name: 'storage-account-key'
+  properties: {
+    value: storage.listKeys().keys[0].value
+  }
+}
+
+resource containerEnv 'Microsoft.App/managedEnvironments@2024-03-01' = {
+  name: containerEnvName
+  location: location
+  properties: {
+    appLogsConfiguration: {
+      destination: 'log-analytics'
+      logAnalyticsConfiguration: {
+        customerId: logAnalytics.properties.customerId
+        sharedKey: logAnalytics.listKeys().primarySharedKey
+      }
+    }
+  }
+}
+
+resource api 'Microsoft.App/containerApps@2024-03-01' = {
+  name: apiName
+  location: location
+  identity: {
+    type: 'SystemAssigned'
+  }
+  properties: {
+    managedEnvironmentId: containerEnv.id
+    configuration: {
+      activeRevisionsMode: 'Single'
+      ingress: {
+        external: true
+        targetPort: 8000
+        transport: 'http'
+      }
+      registries: empty(acrLoginServer) ? [] : [
+        {
+          server: acrLoginServer
+          identity: 'system'
+        }
+      ]
+      secrets: [
+        {
+          name: 'bifrost-docs-secret-key'
+          value: bifrostDocsSecretKey
+        }
+        {
+          name: 'database-url'
+          value: databaseUrl
+        }
+        {
+          name: 'database-url-sync'
+          value: databaseUrlSync
+        }
+        {
+          name: 'storage-account-key'
+          value: storage.listKeys().keys[0].value
+        }
+      ]
+    }
+    template: {
+      scale: {
+        minReplicas: apiMinReplicas
+        maxReplicas: apiMaxReplicas
+        rules: [
+          {
+            name: 'http-scale'
+            http: {
+              metadata: {
+                concurrentRequests: '25'
+              }
+            }
+          }
+        ]
+      }
+      containers: [
+        {
+          name: 'api'
+          image: apiImage
+          resources: {
+            cpu: json('0.5')
+            memory: '1Gi'
+          }
+          env: [
+            {
+              name: 'BIFROST_DOCS_ENVIRONMENT'
+              value: 'production'
+            }
+            {
+              name: 'BIFROST_DOCS_DEBUG'
+              value: 'false'
+            }
+            {
+              name: 'BIFROST_DOCS_SECRET_KEY'
+              secretRef: 'bifrost-docs-secret-key'
+            }
+            {
+              name: 'BIFROST_DOCS_DATABASE_URL'
+              secretRef: 'database-url'
+            }
+            {
+              name: 'BIFROST_DOCS_DATABASE_URL_SYNC'
+              secretRef: 'database-url-sync'
+            }
+            {
+              name: 'BIFROST_DOCS_CORS_ORIGINS'
+              value: corsOrigins
+            }
+            {
+              name: 'BIFROST_DOCS_WEBAUTHN_RP_ID'
+              value: webauthnRpId
+            }
+            {
+              name: 'BIFROST_DOCS_WEBAUTHN_ORIGIN'
+              value: webauthnOrigin
+            }
+            {
+              name: 'BIFROST_DOCS_STORAGE_BACKEND'
+              value: 'azure_blob'
+            }
+            {
+              name: 'BIFROST_DOCS_AZURE_STORAGE_ACCOUNT_URL'
+              value: storage.properties.primaryEndpoints.blob
+            }
+            {
+              name: 'BIFROST_DOCS_AZURE_STORAGE_ACCOUNT_KEY'
+              secretRef: 'storage-account-key'
+            }
+            {
+              name: 'BIFROST_DOCS_AZURE_BLOB_CONTAINER'
+              value: attachmentsContainerName
+            }
+            {
+              name: 'APPLICATIONINSIGHTS_CONNECTION_STRING'
+              value: appInsights.properties.ConnectionString
+            }
+          ]
+          probes: [
+            {
+              type: 'Liveness'
+              httpGet: {
+                path: '/health'
+                port: 8000
+              }
+              initialDelaySeconds: 30
+              periodSeconds: 30
+            }
+          ]
+        }
+      ]
+    }
+  }
+}
+
+resource acrPull 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (!empty(acrName)) {
+  name: guid(api.id, acr.id, 'acrpull')
+  scope: acr
+  properties: {
+    principalId: api.identity.principalId
+    principalType: 'ServicePrincipal'
+    roleDefinitionId: subscriptionResourceId(
+      'Microsoft.Authorization/roleDefinitions',
+      '7f951dda-4ed3-4680-a7ca-43fe172d538d'
+    )
+  }
+}
+
+resource initJob 'Microsoft.App/jobs@2024-03-01' = {
+  name: initJobName
+  location: location
+  properties: {
+    environmentId: containerEnv.id
+    configuration: {
+      triggerType: 'Manual'
+      replicaTimeout: 900
+      replicaRetryLimit: 1
+      manualTriggerConfig: {
+        replicaCompletionCount: 1
+          parallelism: 1
+        }
+      secrets: [
+        {
+          name: 'bifrost-docs-secret-key'
+          value: bifrostDocsSecretKey
+        }
+        {
+          name: 'database-url'
+          value: databaseUrl
+        }
+        {
+          name: 'database-url-sync'
+          value: databaseUrlSync
+        }
+        {
+          name: 'storage-account-key'
+          value: storage.listKeys().keys[0].value
+        }
+      ]
+    }
+    template: {
+      containers: [
+        {
+          name: 'init'
+          image: apiImage
+          command: [
+            'python'
+            '-m'
+            'scripts.init_container'
+          ]
+          resources: {
+            cpu: json('0.5')
+            memory: '1Gi'
+          }
+          env: [
+            {
+              name: 'BIFROST_DOCS_ENVIRONMENT'
+              value: 'production'
+            }
+            {
+              name: 'BIFROST_DOCS_SECRET_KEY'
+              secretRef: 'bifrost-docs-secret-key'
+            }
+            {
+              name: 'BIFROST_DOCS_DATABASE_URL'
+              secretRef: 'database-url'
+            }
+            {
+              name: 'BIFROST_DOCS_DATABASE_URL_SYNC'
+              secretRef: 'database-url-sync'
+            }
+          ]
+        }
+      ]
+    }
+  }
+}
+
+output apiFqdn string = api.properties.configuration.ingress.fqdn
+output apiUrl string = 'https://${api.properties.configuration.ingress.fqdn}'
+output storageAccountName string = storage.name
+output keyVaultName string = keyVault.name
+output staticWebsiteUrl string = storage.properties.primaryEndpoints.web
+output attachmentsContainer string = attachmentsContainerName
+output backupsContainer string = backupsContainerName
+output initJobName string = initJob.name

--- a/infra/azure-neon/main.bicep
+++ b/infra/azure-neon/main.bicep
@@ -122,7 +122,6 @@ resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' = {
       name: 'standard'
     }
     enableRbacAuthorization: true
-    enablePurgeProtection: false
     enabledForTemplateDeployment: true
     publicNetworkAccess: 'Enabled'
   }
@@ -244,6 +243,10 @@ resource api 'Microsoft.App/containerApps@2024-03-01' = {
             }
             {
               name: 'BIFROST_DOCS_DEBUG'
+              value: 'false'
+            }
+            {
+              name: 'BIFROST_DOCS_RATE_LIMITING_ENABLED'
               value: 'false'
             }
             {

--- a/scripts/deploy-azure-neon-proof.ps1
+++ b/scripts/deploy-azure-neon-proof.ps1
@@ -1,0 +1,136 @@
+param(
+    [string]$SubscriptionName = "Azure Sponsorship",
+    [string]$ResourceGroupName = "rg-bifrost-docs-neon-dev",
+    [string]$Location = "eastus",
+    [string]$EnvironmentName = "neon-dev",
+    [string]$ApiImage = "",
+    [string]$AcrName = "",
+    [string]$AcrLoginServer = "",
+    [Parameter(Mandatory = $true)]
+    [string]$DatabaseUrl,
+    [Parameter(Mandatory = $true)]
+    [string]$DatabaseUrlSync,
+    [string]$BifrostDocsSecretKey = "",
+    [switch]$SkipFrontendBuild,
+    [switch]$SkipInitJob
+)
+
+$ErrorActionPreference = "Stop"
+
+function Require-Command($Name) {
+    if (-not (Get-Command $Name -ErrorAction SilentlyContinue)) {
+        throw "Required command '$Name' was not found on PATH."
+    }
+}
+
+Require-Command az
+Require-Command git
+
+if (-not $ApiImage) {
+    $shortSha = (git rev-parse --short=7 HEAD).Trim()
+    $ApiImage = "ghcr.io/mtg-thomas/bifrost-docs-api:$shortSha"
+}
+
+if (-not $BifrostDocsSecretKey) {
+    $bytes = [byte[]]::new(48)
+    [System.Security.Cryptography.RandomNumberGenerator]::Fill($bytes)
+    $BifrostDocsSecretKey = [Convert]::ToBase64String($bytes)
+}
+
+Write-Host "Using subscription: $SubscriptionName"
+az account set --subscription $SubscriptionName
+
+Write-Host "Ensuring resource group: $ResourceGroupName ($Location)"
+az group create --name $ResourceGroupName --location $Location | Out-Null
+
+$placeholderOrigin = "https://placeholder.invalid"
+$placeholderRpId = "placeholder.invalid"
+
+Write-Host "Deploying Azure baseline and API container app..."
+$deployment = az deployment group create `
+    --resource-group $ResourceGroupName `
+    --template-file "infra/azure-neon/main.bicep" `
+    --parameters `
+        location=$Location `
+        environmentName=$EnvironmentName `
+        apiImage=$ApiImage `
+        acrName=$AcrName `
+        acrLoginServer=$AcrLoginServer `
+        corsOrigins=$placeholderOrigin `
+        webauthnRpId=$placeholderRpId `
+        webauthnOrigin=$placeholderOrigin `
+        bifrostDocsSecretKey=$BifrostDocsSecretKey `
+        databaseUrl=$DatabaseUrl `
+        databaseUrlSync=$DatabaseUrlSync `
+    --query properties.outputs `
+    --output json | ConvertFrom-Json
+
+$apiUrl = $deployment.apiUrl.value
+$apiFqdn = $deployment.apiFqdn.value
+$staticWebsiteUrl = ($deployment.staticWebsiteUrl.value).TrimEnd("/")
+$storageAccountName = $deployment.storageAccountName.value
+$initJobName = $deployment.initJobName.value
+$apiContainerAppName = "ca-bifrost-docs-api-$EnvironmentName"
+$storageKey = az storage account keys list `
+    --resource-group $ResourceGroupName `
+    --account-name $storageAccountName `
+    --query "[0].value" `
+    --output tsv
+
+Write-Host "Enabling static website hosting on storage account..."
+az storage blob service-properties update `
+    --account-name $storageAccountName `
+    --account-key $storageKey `
+    --static-website `
+    --index-document index.html `
+    --404-document index.html `
+    | Out-Null
+
+Write-Host "API URL: $apiUrl"
+Write-Host "Static website URL: $staticWebsiteUrl"
+
+Write-Host "Updating API CORS/WebAuthn origin to static website URL..."
+az containerapp update `
+    --resource-group $ResourceGroupName `
+    --name $apiContainerAppName `
+    --set-env-vars `
+        "BIFROST_DOCS_CORS_ORIGINS=$staticWebsiteUrl" `
+        "BIFROST_DOCS_WEBAUTHN_ORIGIN=$staticWebsiteUrl" `
+        "BIFROST_DOCS_WEBAUTHN_RP_ID=$(($staticWebsiteUrl -replace '^https?://','' -replace '/$',''))" `
+    | Out-Null
+
+if (-not $SkipInitJob) {
+    Write-Host "Starting migration/init job: $initJobName"
+    az containerapp job start `
+        --resource-group $ResourceGroupName `
+        --name $initJobName `
+        | Out-Null
+}
+
+if (-not $SkipFrontendBuild) {
+    Require-Command npm
+    Push-Location client
+    try {
+        Write-Host "Building frontend with VITE_API_URL=$apiUrl"
+        $env:VITE_API_URL = $apiUrl
+        npm ci
+        npm run build
+    }
+    finally {
+        Pop-Location
+    }
+
+    Write-Host "Uploading frontend to Azure Storage static website..."
+    az storage blob upload-batch `
+        --account-name $storageAccountName `
+        --account-key $storageKey `
+        --destination '$web' `
+        --source 'client/dist' `
+        --overwrite `
+        | Out-Null
+}
+
+Write-Host "Proof deployment submitted."
+Write-Host "Frontend: $staticWebsiteUrl"
+Write-Host "API:      $apiUrl"
+Write-Host "Health:   $apiUrl/health"

--- a/scripts/export-dev-vm-db.ps1
+++ b/scripts/export-dev-vm-db.ps1
@@ -1,0 +1,60 @@
+param(
+    [string]$VmHost = "bifrost-docs-dev.netbird.cloud",
+    [string]$VmUser = "thomas",
+    [string]$DeployRoot = "/home/thomas/deploy/bifrost-docs-main",
+    [string]$ComposeProject = "bifrost-docs-dev",
+    [string]$OutputDirectory = ".migration-runs/azure-neon-proof",
+    [string]$OutputPrefix = "bifrost-docs-dev"
+)
+
+$ErrorActionPreference = "Stop"
+if ($PSVersionTable.PSVersion.Major -ge 7) {
+    $PSNativeCommandUseErrorActionPreference = $true
+}
+
+$timestamp = Get-Date -Format "yyyyMMdd-HHmmss"
+$localOutput = Join-Path $OutputDirectory $timestamp
+New-Item -ItemType Directory -Force -Path $localOutput | Out-Null
+
+$remoteDump = "/tmp/$OutputPrefix-$timestamp.dump"
+$remoteStats = "/tmp/$OutputPrefix-$timestamp-stats.txt"
+$localDump = Join-Path $localOutput "$OutputPrefix.dump"
+$localStats = Join-Path $localOutput "$OutputPrefix-stats.txt"
+$compose = "docker compose -p '$ComposeProject' -f docker-compose.yml -f docker-compose.test-vm.yml -f docker-compose.ssl.yml"
+$sshOptions = @(
+    "-o", "BatchMode=yes",
+    "-o", "ConnectTimeout=10",
+    "-o", "StrictHostKeyChecking=no",
+    "-o", "UserKnownHostsFile=NUL"
+)
+
+$sshTarget = "$VmUser@$VmHost"
+$dumpCommand = "cd '$DeployRoot' && $compose exec -T postgres pg_dump -U bifrost_docs -d bifrost_docs --format=custom --no-owner --no-acl > '$remoteDump'"
+ssh @sshOptions $sshTarget $dumpCommand
+if ($LASTEXITCODE -ne 0) { throw "Remote pg_dump failed with exit code $LASTEXITCODE" }
+
+scp @sshOptions "$sshTarget`:$remoteDump" $localDump
+if ($LASTEXITCODE -ne 0) { throw "scp dump failed with exit code $LASTEXITCODE" }
+
+$statsSql = @"
+SELECT pg_size_pretty(pg_database_size('bifrost_docs')) AS database_size;
+SELECT 'organizations' AS table_name, COUNT(*) AS row_count FROM organizations
+UNION ALL SELECT 'documents', COUNT(*) FROM documents
+UNION ALL SELECT 'attachments', COUNT(*) FROM attachments
+UNION ALL SELECT 'passwords', COUNT(*) FROM passwords
+UNION ALL SELECT 'relationships', COUNT(*) FROM relationships
+UNION ALL SELECT 'embedding_index', COUNT(*) FROM embedding_index
+ORDER BY table_name;
+"@
+$statsBase64 = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($statsSql))
+$statsCommand = "cd '$DeployRoot' && printf '%s' '$statsBase64' | base64 -d | $compose exec -T postgres psql -U bifrost_docs -d bifrost_docs -v ON_ERROR_STOP=1 > '$remoteStats'"
+ssh @sshOptions $sshTarget $statsCommand
+if ($LASTEXITCODE -ne 0) { throw "Remote stats query failed with exit code $LASTEXITCODE" }
+
+scp @sshOptions "$sshTarget`:$remoteStats" $localStats
+if ($LASTEXITCODE -ne 0) { throw "scp stats failed with exit code $LASTEXITCODE" }
+
+ssh @sshOptions $sshTarget "rm -f '$remoteDump' '$remoteStats'"
+
+Write-Host "Exported database dump: $localDump"
+Write-Host "Exported database stats: $localStats"

--- a/scripts/restore-neon-db.ps1
+++ b/scripts/restore-neon-db.ps1
@@ -1,0 +1,21 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$DumpPath,
+    [Parameter(Mandatory = $true)]
+    [string]$DatabaseUrlSync
+)
+
+$ErrorActionPreference = "Stop"
+
+if (-not (Get-Command pg_restore -ErrorAction SilentlyContinue)) {
+    throw "pg_restore was not found on PATH. Install PostgreSQL client tools first."
+}
+
+if (-not (Test-Path $DumpPath)) {
+    throw "Dump path not found: $DumpPath"
+}
+
+Write-Host "Restoring $DumpPath into Neon target..."
+pg_restore --dbname $DatabaseUrlSync --clean --if-exists --no-owner --no-acl $DumpPath
+
+Write-Host "Restore complete."

--- a/tools/itglue-migrate/src/itglue_migrate/api_client.py
+++ b/tools/itglue-migrate/src/itglue_migrate/api_client.py
@@ -1434,12 +1434,15 @@ class BifrostDocsClient:
         """
         # Rewrite Docker-internal URLs for local development
         upload_url = _rewrite_docker_url(upload_url)
+        headers = {"Content-Type": content_type}
+        if ".blob.core.windows.net/" in upload_url:
+            headers["x-ms-blob-type"] = "BlockBlob"
 
         async with httpx.AsyncClient(timeout=httpx.Timeout(300.0)) as client:
             response = await client.put(
                 upload_url,
                 content=file_content,
-                headers={"Content-Type": content_type},
+                headers=headers,
             )
             if response.status_code >= 400:
                 raise APIError(


### PR DESCRIPTION
## Summary
- Add Azure Blob storage support behind the existing file storage service
- Add Azure + Neon proof deployment Bicep, scripts, docs, and manual image workflow path
- Allow proof deployments to disable Redis-backed rate limiting while keeping production default enabled

## Proof deployment
- Frontend: https://bifdocsneondevgctvavcfha.z13.web.core.windows.net/
- API: https://ca-bifrost-docs-api-neon-dev.icymoss-8e8097f1.eastus.azurecontainerapps.io
- API image: ghcr.io/mtg-thomas/bifrost-docs-api:573f2d2
- Neon restore smoke: organizations 1, documents 446, attachments 615, passwords 84, relationships 34, embedding_index 0

## Verification
- `python -m ruff check src\config.py src\core\rate_limiting.py`
- `python -m ruff format --check src\config.py src\core\rate_limiting.py`
- `python -m pyright src\config.py src\core\rate_limiting.py`
- `az bicep build --file infra\azure-neon\main.bicep`
- GitHub Actions CI run 24946828770 passed backend/frontend/image jobs
- Live `/health` returns healthy
- Live `/health/detailed` reports database healthy and Redis degraded/optional
- Static website returns HTTP 200

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional Azure Blob storage backend for attachments and a runtime toggle to enable/disable rate limiting
  * Manual workflows to build/publish API images and frontend proofs; Azure Static Web Apps deploy with AAD auth

* **Documentation**
  * Azure-Neon proof deployment runbook and Static Web Apps guidance

* **Chores**
  * Azure deployment templates, automation scripts, CI workflow updates, and added Azure storage dependency
  * API response schemas relaxed to accept UUID or string for several fields

* **Tests**
  * Unit tests covering Azure storage backend and rate-limiting configuration
<!-- end of auto-generated comment: release notes by coderabbit.ai -->