### PR TITLE
ci: bound authenticated ZAP API scan

### DIFF
--- a/.github/workflows/zap-authenticated-api.yml
+++ b/.github/workflows/zap-authenticated-api.yml
@@ -16,6 +16,7 @@ jobs:
     name: ZAP authenticated API scan
     runs-on: ubuntu-latest
     environment: azure-neon-proof
+    timeout-minutes: 15
 
     env:
       API_URL: https://ca-bifrost-docs-api-neon-dev.icymoss-8e8097f1.eastus.azurecontainerapps.io
@@ -42,6 +43,8 @@ jobs:
             zap-api-scan.py \
               -t "${API_URL}/openapi.json" \
               -f openapi \
+              -S \
+              -T 5 \
               -c /zap/wrk/.zap/api-scan-rules.tsv \
               -J zap-authenticated-api/zap-api.json \
               -r zap-authenticated-api/zap-api.html \


### PR DESCRIPTION
## Summary
- add a 15-minute job timeout to the authenticated ZAP API scan
- run zap-api-scan.py in safe mode with a bounded passive-scan wait

## Notes
This keeps the authenticated API workflow aligned with the proof-stage intent: passive/API-safe coverage only, with no active scan behavior.

## Test Plan
- rerun OWASP ZAP Authenticated API after merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security scanning workflow with a 15-minute maximum runtime limit for the authenticated API scan job and optimized scan execution parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->