### PR TITLE
ci: preserve authenticated ZAP failures

### DIFF
--- a/.github/workflows/zap-authenticated-api.yml
+++ b/.github/workflows/zap-authenticated-api.yml
@@ -35,7 +35,9 @@ jobs:
 
       - name: Run authenticated passive OpenAPI scan
         run: |
+          set -o pipefail
           mkdir -p zap-authenticated-api
+          chmod 777 zap-authenticated-api
           docker run --rm \
             -v "${PWD}:/zap/wrk/:rw" \
             -e ZAP_AUTH_HEADER_VALUE \


### PR DESCRIPTION
## Summary
- make the authenticated ZAP shell pipeline fail when zap-api-scan.py fails
- allow the ZAP container user to write JSON/HTML/Markdown artifacts into the mounted report directory

## Why
The first successful authenticated run reported findings in the console, but report generation hit a write-permission error that was hidden by the 	ee pipeline exit code.

## Test Plan
- rerun OWASP ZAP Authenticated API after merge and inspect uploaded artifacts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved reliability of automated API security scanning by enhancing error detection in pipeline execution.
  * Refined directory permission handling for the scanning process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->