### PR TITLE
fix: harden authenticated ZAP findings

### DIFF
--- a/api/src/core/security_headers.py
+++ b/api/src/core/security_headers.py
@@ -29,85 +29,91 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
 
     async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
         response = await call_next(request)
-        settings = get_settings()
+        add_security_headers_to_response(response)
+        return response
 
-        # Prevent MIME type sniffing
-        response.headers["X-Content-Type-Options"] = "nosniff"
 
-        # Prevent clickjacking
-        response.headers["X-Frame-Options"] = "DENY"
+def add_security_headers_to_response(response: Response) -> Response:
+    """Apply Bifrost Docs security headers to a response object."""
+    settings = get_settings()
 
-        # Legacy XSS protection for older browsers
-        response.headers["X-XSS-Protection"] = "1; mode=block"
+    # Prevent MIME type sniffing
+    response.headers["X-Content-Type-Options"] = "nosniff"
 
-        # Referrer policy
-        response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
+    # Prevent clickjacking
+    response.headers["X-Frame-Options"] = "DENY"
 
-        # The API is called cross-origin by the Azure Static Web Apps frontend.
-        # Use an explicit CORP value so browsers and scanners do not have to
-        # infer policy from a missing header.
-        response.headers["Cross-Origin-Resource-Policy"] = "cross-origin"
+    # Legacy XSS protection for older browsers
+    response.headers["X-XSS-Protection"] = "1; mode=block"
 
-        # API responses can contain documentation, passwords metadata, auth
-        # state, presigned URLs, or other sensitive tenant data. Prefer no-store
-        # by default; static frontend assets are served outside this API.
-        response.headers["Cache-Control"] = "no-cache, no-store, must-revalidate"
-        response.headers["Pragma"] = "no-cache"
-        response.headers["Expires"] = "0"
+    # Referrer policy
+    response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
 
-        # Permissions policy (formerly Feature-Policy)
-        response.headers["Permissions-Policy"] = (
-            "accelerometer=(), "
-            "camera=(), "
-            "geolocation=(), "
-            "gyroscope=(), "
-            "magnetometer=(), "
-            "microphone=(), "
-            "payment=(), "
-            "usb=()"
+    # The API is called cross-origin by the Azure Static Web Apps frontend.
+    # Use an explicit CORP value so browsers and scanners do not have to
+    # infer policy from a missing header.
+    response.headers["Cross-Origin-Resource-Policy"] = "cross-origin"
+
+    # API responses can contain documentation, passwords metadata, auth
+    # state, presigned URLs, or other sensitive tenant data. Prefer no-store
+    # by default; static frontend assets are served outside this API.
+    response.headers["Cache-Control"] = "no-cache, no-store, must-revalidate"
+    response.headers["Pragma"] = "no-cache"
+    response.headers["Expires"] = "0"
+
+    # Permissions policy (formerly Feature-Policy)
+    response.headers["Permissions-Policy"] = (
+        "accelerometer=(), "
+        "camera=(), "
+        "geolocation=(), "
+        "gyroscope=(), "
+        "magnetometer=(), "
+        "microphone=(), "
+        "payment=(), "
+        "usb=()"
+    )
+
+    # HSTS (only in production and if using HTTPS)
+    if settings.environment == "production":
+        response.headers["Strict-Transport-Security"] = (
+            "max-age=31536000; includeSubDomains; preload"
         )
 
-        # HSTS (only in production and if using HTTPS)
-        if settings.environment == "production":
-            response.headers["Strict-Transport-Security"] = (
-                "max-age=31536000; includeSubDomains; preload"
-            )
+    # Content Security Policy
+    # More restrictive in production, more permissive in development
+    if settings.environment == "production":
+        # Strict CSP for production
+        csp_directives = [
+            "default-src 'self'",
+            "script-src 'self'",
+            "style-src 'self' 'unsafe-inline'",  # Allow inline styles (needed for many UI frameworks)
+            "img-src 'self' data: blob:",
+            "font-src 'self'",
+            "connect-src 'self'",
+            "media-src 'self'",
+            "object-src 'none'",
+            "frame-ancestors 'none'",
+            "base-uri 'self'",
+            "form-action 'self'",
+        ]
+    else:
+        # More permissive CSP for development (allows eval, inline scripts)
+        csp_directives = [
+            "default-src 'self'",
+            "script-src 'self' 'unsafe-inline' 'unsafe-eval'",  # Needed for Vite HMR
+            "style-src 'self' 'unsafe-inline'",
+            "img-src 'self' data: blob: https:",
+            "font-src 'self' data:",
+            "connect-src 'self' ws: wss:",  # Allow WebSocket for HMR
+            "media-src 'self'",
+            "object-src 'none'",
+            "frame-ancestors 'none'",
+            "form-action 'self'",
+        ]
 
-        # Content Security Policy
-        # More restrictive in production, more permissive in development
-        if settings.environment == "production":
-            # Strict CSP for production
-            csp_directives = [
-                "default-src 'self'",
-                "script-src 'self'",
-                "style-src 'self' 'unsafe-inline'",  # Allow inline styles (needed for many UI frameworks)
-                "img-src 'self' data: blob:",
-                "font-src 'self'",
-                "connect-src 'self'",
-                "media-src 'self'",
-                "object-src 'none'",
-                "frame-ancestors 'none'",
-                "base-uri 'self'",
-                "form-action 'self'",
-            ]
-        else:
-            # More permissive CSP for development (allows eval, inline scripts)
-            csp_directives = [
-                "default-src 'self'",
-                "script-src 'self' 'unsafe-inline' 'unsafe-eval'",  # Needed for Vite HMR
-                "style-src 'self' 'unsafe-inline'",
-                "img-src 'self' data: blob: https:",
-                "font-src 'self' data:",
-                "connect-src 'self' ws: wss:",  # Allow WebSocket for HMR
-                "media-src 'self'",
-                "object-src 'none'",
-                "frame-ancestors 'none'",
-                "form-action 'self'",
-            ]
+    response.headers["Content-Security-Policy"] = "; ".join(csp_directives)
 
-        response.headers["Content-Security-Policy"] = "; ".join(csp_directives)
-
-        return response
+    return response
 
 
 def add_security_headers(app):

--- a/api/src/main.py
+++ b/api/src/main.py
@@ -187,7 +187,10 @@ def create_app() -> FastAPI:
     # ==========================================================================
     # Security Headers Middleware
     # ==========================================================================
-    from src.core.security_headers import SecurityHeadersMiddleware
+    from src.core.security_headers import (
+        SecurityHeadersMiddleware,
+        add_security_headers_to_response,
+    )
 
     app.add_middleware(SecurityHeadersMiddleware)
     logger.info("Security headers middleware enabled")
@@ -196,6 +199,14 @@ def create_app() -> FastAPI:
     # Global Exception Handlers
     # ==========================================================================
 
+    def _json_error_response(status_code: int, error: ErrorResponse) -> JSONResponse:
+        response = JSONResponse(
+            status_code=status_code,
+            content=error.model_dump(),
+        )
+        add_security_headers_to_response(response)
+        return response
+
     @app.exception_handler(PydanticValidationError)
     async def pydantic_validation_handler(
         request: Request, exc: PydanticValidationError
@@ -203,13 +214,13 @@ def create_app() -> FastAPI:
         """Pydantic model validation errors -> 422."""
         errors = exc.errors()
         field_errors = {".".join(str(loc) for loc in e["loc"]): e["msg"] for e in errors}
-        return JSONResponse(
-            status_code=422,
-            content=ErrorResponse(
+        return _json_error_response(
+            422,
+            ErrorResponse(
                 error="validation_error",
                 message="Validation failed",
                 details={"fields": field_errors},
-            ).model_dump(),
+            ),
         )
 
     @app.exception_handler(IntegrityError)
@@ -225,46 +236,46 @@ def create_app() -> FastAPI:
             message = "Database constraint violation"
 
         logger.warning(f"IntegrityError: {detail}")
-        return JSONResponse(
-            status_code=409,
-            content=ErrorResponse(
+        return _json_error_response(
+            409,
+            ErrorResponse(
                 error="conflict",
                 message=message,
-            ).model_dump(),
+            ),
         )
 
     @app.exception_handler(NoResultFound)
     async def no_result_handler(request: Request, exc: NoResultFound) -> JSONResponse:
         """Query returned no results -> 404."""
-        return JSONResponse(
-            status_code=404,
-            content=ErrorResponse(
+        return _json_error_response(
+            404,
+            ErrorResponse(
                 error="not_found",
                 message="Resource not found",
-            ).model_dump(),
+            ),
         )
 
     @app.exception_handler(ValueError)
     async def value_error_handler(request: Request, exc: ValueError) -> JSONResponse:
         """ValueError from validation -> 422."""
-        return JSONResponse(
-            status_code=422,
-            content=ErrorResponse(
+        return _json_error_response(
+            422,
+            ErrorResponse(
                 error="validation_error",
                 message=str(exc),
-            ).model_dump(),
+            ),
         )
 
     @app.exception_handler(OperationalError)
     async def operational_error_handler(request: Request, exc: OperationalError) -> JSONResponse:
         """Database connection issues -> 503."""
         logger.error(f"Database operational error: {exc}", exc_info=True)
-        return JSONResponse(
-            status_code=503,
-            content=ErrorResponse(
+        return _json_error_response(
+            503,
+            ErrorResponse(
                 error="service_unavailable",
                 message="Service temporarily unavailable",
-            ).model_dump(),
+            ),
         )
 
     @app.exception_handler(Exception)
@@ -274,12 +285,12 @@ def create_app() -> FastAPI:
             f"Unhandled exception on {request.method} {request.url.path}: {exc}",
             exc_info=True,
         )
-        return JSONResponse(
-            status_code=500,
-            content=ErrorResponse(
+        return _json_error_response(
+            500,
+            ErrorResponse(
                 error="internal_error",
                 message="An unexpected error occurred",
-            ).model_dump(),
+            ),
         )
 
     # ==========================================================================

--- a/api/src/routers/auth.py
+++ b/api/src/routers/auth.py
@@ -591,7 +591,7 @@ async def setup_passkey_verify(
     """
     import json
 
-    from src.services.passkey_service import PasskeyService
+    from src.services.passkey_service import PasskeyService, PasskeyValidationError
 
     passkey_service = PasskeyService(db)
 
@@ -602,6 +602,12 @@ async def setup_passkey_verify(
             device_name=verify_request.device_name,
         )
         await db.commit()
+    except PasskeyValidationError as e:
+        logger.warning("Invalid setup passkey response", exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid passkey setup response",
+        ) from e
     except ValueError as e:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,

--- a/api/src/routers/oauth_sso.py
+++ b/api/src/routers/oauth_sso.py
@@ -282,9 +282,6 @@ async def oauth_callback(
             detail="Invalid or expired OAuth state",
         )
 
-    # Delete state immediately (single-use)
-    await r.delete(state_key)
-
     # Parse state data (contains code_verifier and redirect_uri)
     if isinstance(state_data_raw, bytes):
         state_data_raw = state_data_raw.decode("utf-8")
@@ -299,6 +296,9 @@ async def oauth_callback(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Invalid OAuth state data",
         ) from e
+
+    # Delete state before provider token exchange so parsed state remains single-use.
+    await r.delete(state_key)
 
     try:
         # Exchange code for tokens using server-side verifier
@@ -325,7 +325,7 @@ async def oauth_callback(
         logger.error(f"OAuth callback error: {e}")
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=str(e),
+            detail="OAuth callback failed",
         ) from e
 
     # Check if user already has an OAuth account linked

--- a/api/src/routers/passkeys.py
+++ b/api/src/routers/passkeys.py
@@ -38,7 +38,7 @@ from src.models.contracts.passkeys import (
 from src.models.enums import AuditAction
 from src.routers.auth import set_auth_cookies
 from src.services.audit_service import get_audit_service
-from src.services.passkey_service import PasskeyService, UserPasskey
+from src.services.passkey_service import PasskeyService, PasskeyValidationError, UserPasskey
 
 logger = logging.getLogger(__name__)
 
@@ -124,6 +124,16 @@ async def verify_registration(
             passkey_id=passkey.id,
             name=passkey.name,
         )
+    except PasskeyValidationError as e:
+        logger.warning(
+            "Invalid passkey registration response for user %s",
+            user.user_id,
+            exc_info=True,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid passkey registration response",
+        ) from e
     except ValueError as e:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -225,6 +235,13 @@ async def verify_authentication(
         # Generate login tokens (same as password login)
         return await _generate_login_tokens(user, db, response)
 
+    except PasskeyValidationError as e:
+        logger.warning("Invalid passkey authentication response", exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid passkey authentication response",
+            headers={"WWW-Authenticate": "Bearer"},
+        ) from e
     except ValueError as e:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,

--- a/api/src/services/passkey_service.py
+++ b/api/src/services/passkey_service.py
@@ -46,6 +46,10 @@ PASSKEY_SETUP_TOKEN_PREFIX = "passkey_setup:"
 CHALLENGE_TTL_SECONDS = 300  # 5 minutes
 
 
+class PasskeyValidationError(ValueError):
+    """Raised when a browser-provided WebAuthn credential cannot be validated."""
+
+
 class PasskeyService:
     """Service for WebAuthn passkey operations."""
 
@@ -157,11 +161,8 @@ class PasskeyService:
 
         expected_challenge = base64url_to_bytes(challenge_b64)
 
-        # Parse the credential JSON
-        credential = parse_registration_credential_json(credential_json)
-
-        # Verify the registration response
         try:
+            credential = parse_registration_credential_json(credential_json)
             verification = verify_registration_response(
                 credential=credential,
                 expected_challenge=expected_challenge,
@@ -169,7 +170,7 @@ class PasskeyService:
                 expected_rp_id=self.settings.webauthn_rp_id,
             )
         except Exception as e:
-            raise ValueError(f"Registration verification failed: {e}") from e
+            raise PasskeyValidationError("Invalid passkey registration response") from e
 
         # Extract transports from credential response if available
         transports = []
@@ -273,13 +274,15 @@ class PasskeyService:
 
         expected_challenge = base64url_to_bytes(challenge_b64)
 
-        # Parse the credential JSON
-        credential = parse_authentication_credential_json(credential_json)
+        try:
+            credential = parse_authentication_credential_json(credential_json)
+        except Exception as e:
+            raise PasskeyValidationError("Invalid passkey authentication response") from e
 
         # Find the passkey by credential ID
         passkey = await self._get_passkey_by_credential_id(credential.raw_id)
         if not passkey:
-            raise ValueError("Unknown credential")
+            raise PasskeyValidationError("Invalid passkey authentication response")
 
         # Verify the authentication response
         try:
@@ -292,7 +295,7 @@ class PasskeyService:
                 credential_current_sign_count=passkey.sign_count,
             )
         except Exception as e:
-            raise ValueError(f"Authentication verification failed: {e}") from e
+            raise PasskeyValidationError("Invalid passkey authentication response") from e
 
         # Update sign count and last used (prevents replay attacks)
         passkey.sign_count = verification.new_sign_count
@@ -456,14 +459,10 @@ class PasskeyService:
             raise ValueError("Registration token not found or expired")
         await redis.delete(setup_key)
 
-        setup_data = json.loads(setup_data_json)
-        expected_challenge = base64url_to_bytes(setup_data["challenge"])
-
-        # Parse the credential JSON
-        credential = parse_registration_credential_json(credential_json)
-
-        # Verify the registration response
         try:
+            setup_data = json.loads(setup_data_json)
+            expected_challenge = base64url_to_bytes(setup_data["challenge"])
+            credential = parse_registration_credential_json(credential_json)
             verification = verify_registration_response(
                 credential=credential,
                 expected_challenge=expected_challenge,
@@ -471,7 +470,7 @@ class PasskeyService:
                 expected_rp_id=self.settings.webauthn_rp_id,
             )
         except Exception as e:
-            raise ValueError(f"Registration verification failed: {e}") from e
+            raise PasskeyValidationError("Invalid passkey setup response") from e
 
         # Double-check first-user scenario (race condition protection)
         user_repo = UserRepository(self.db)

--- a/api/tests/unit/services/test_passkey_validation_errors.py
+++ b/api/tests/unit/services/test_passkey_validation_errors.py
@@ -1,0 +1,84 @@
+import json
+from types import MethodType, SimpleNamespace
+from uuid import uuid4
+
+import pytest
+
+from src.services.passkey_service import PasskeyService, PasskeyValidationError
+
+
+class FakeRedis:
+    def __init__(self, value):
+        self.value = value
+        self.deleted = []
+
+    async def get(self, key):
+        return self.value
+
+    async def delete(self, key):
+        self.deleted.append(key)
+
+
+def _redis_factory(redis: FakeRedis):
+    async def get_fake_redis():
+        return redis
+
+    return get_fake_redis
+
+
+@pytest.mark.asyncio
+async def test_verify_registration_wraps_malformed_credential(monkeypatch):
+    redis = FakeRedis("YWJj")
+    monkeypatch.setattr("src.services.passkey_service.get_redis", _redis_factory(redis))
+
+    service = PasskeyService(db=object())
+    user_id = uuid4()
+
+    async def get_user_by_id(self, requested_user_id):
+        assert requested_user_id == user_id
+        return SimpleNamespace(id=user_id)
+
+    service._get_user_by_id = MethodType(get_user_by_id, service)
+
+    with pytest.raises(PasskeyValidationError, match="Invalid passkey registration response"):
+        await service.verify_registration(
+            user_id=user_id,
+            credential_json=json.dumps({"not": "webauthn"}),
+        )
+
+
+@pytest.mark.asyncio
+async def test_verify_authentication_wraps_malformed_credential(monkeypatch):
+    redis = FakeRedis("YWJj")
+    monkeypatch.setattr("src.services.passkey_service.get_redis", _redis_factory(redis))
+
+    service = PasskeyService(db=object())
+
+    with pytest.raises(PasskeyValidationError, match="Invalid passkey authentication response"):
+        await service.verify_authentication(
+            challenge_id="challenge",
+            credential_json=json.dumps({"not": "webauthn"}),
+        )
+
+
+@pytest.mark.asyncio
+async def test_verify_setup_registration_wraps_malformed_credential(monkeypatch):
+    redis = FakeRedis(
+        json.dumps(
+            {
+                "email": "owner@example.com",
+                "name": "Owner",
+                "challenge": "YWJj",
+                "webauthn_user_id": "YWJj",
+            }
+        )
+    )
+    monkeypatch.setattr("src.services.passkey_service.get_redis", _redis_factory(redis))
+
+    service = PasskeyService(db=object())
+
+    with pytest.raises(PasskeyValidationError, match="Invalid passkey setup response"):
+        await service.verify_setup_registration(
+            registration_token="token",
+            credential_json=json.dumps({"not": "webauthn"}),
+        )

--- a/api/tests/unit/test_auth_setup_passkeys_router.py
+++ b/api/tests/unit/test_auth_setup_passkeys_router.py
@@ -1,0 +1,73 @@
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from src.core.database import get_db
+from src.core.rate_limiting import limiter
+from src.routers.auth import router
+from src.services.passkey_service import PasskeyValidationError
+
+
+class FakeDb:
+    async def commit(self):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_setup_passkey_verify_malformed_credential_returns_400(monkeypatch):
+    monkeypatch.setattr(limiter, "enabled", False)
+
+    app = FastAPI()
+    app.include_router(router)
+
+    class FakePasskeyService:
+        def __init__(self, db):
+            self.db = db
+
+        async def verify_setup_registration(
+            self, registration_token, credential_json, device_name=None
+        ):
+            raise PasskeyValidationError("parser detail that should not leak")
+
+    app.dependency_overrides[get_db] = lambda: FakeDb()
+    monkeypatch.setattr("src.services.passkey_service.PasskeyService", FakePasskeyService)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.post(
+            "/auth/setup/passkey/verify",
+            json={"registration_token": "token", "credential": {"not": "webauthn"}},
+        )
+
+    assert response.status_code == 400
+    assert response.json() == {"detail": "Invalid passkey setup response"}
+
+
+@pytest.mark.asyncio
+async def test_setup_passkey_verify_invalid_token_returns_400_without_leaking_parser(
+    monkeypatch,
+):
+    monkeypatch.setattr(limiter, "enabled", False)
+
+    app = FastAPI()
+    app.include_router(router)
+
+    class FakePasskeyService:
+        def __init__(self, db):
+            self.db = db
+
+        async def verify_setup_registration(
+            self, registration_token, credential_json, device_name=None
+        ):
+            raise ValueError("Registration token not found or expired")
+
+    app.dependency_overrides[get_db] = lambda: FakeDb()
+    monkeypatch.setattr("src.services.passkey_service.PasskeyService", FakePasskeyService)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.post(
+            "/auth/setup/passkey/verify",
+            json={"registration_token": "expired", "credential": {"not": "webauthn"}},
+        )
+
+    assert response.status_code == 400
+    assert response.json() == {"detail": "Registration token not found or expired"}

--- a/api/tests/unit/test_oauth_sso_router.py
+++ b/api/tests/unit/test_oauth_sso_router.py
@@ -1,0 +1,107 @@
+import json
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from src.core.database import get_db
+from src.routers.oauth_sso import router
+from src.services.oauth_sso import OAuthError
+
+
+class FakeDb:
+    pass
+
+
+class FakeRedis:
+    def __init__(self, value):
+        self.value = value
+        self.deleted = []
+
+    async def get(self, key):
+        return self.value
+
+    async def delete(self, key):
+        self.deleted.append(key)
+
+
+def _app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(router)
+    app.dependency_overrides[get_db] = lambda: FakeDb()
+    return app
+
+
+def _redis_factory(redis: FakeRedis):
+    async def get_fake_redis():
+        return redis
+
+    return get_fake_redis
+
+
+@pytest.mark.asyncio
+async def test_oauth_callback_invalid_state_returns_400(monkeypatch):
+    redis = FakeRedis(None)
+    monkeypatch.setattr("src.routers.oauth_sso.get_redis", _redis_factory(redis))
+
+    async with AsyncClient(transport=ASGITransport(app=_app()), base_url="http://test") as client:
+        response = await client.post(
+            "/auth/oauth/callback",
+            json={"provider": "microsoft", "code": "code", "state": "missing"},
+        )
+
+    assert response.status_code == 400
+    assert response.json() == {"detail": "Invalid or expired OAuth state"}
+    assert redis.deleted == []
+
+
+@pytest.mark.asyncio
+async def test_oauth_callback_malformed_cached_state_returns_400_without_consuming_state(
+    monkeypatch,
+):
+    redis = FakeRedis("not-json")
+    monkeypatch.setattr("src.routers.oauth_sso.get_redis", _redis_factory(redis))
+
+    async with AsyncClient(transport=ASGITransport(app=_app()), base_url="http://test") as client:
+        response = await client.post(
+            "/auth/oauth/callback",
+            json={"provider": "microsoft", "code": "code", "state": "malformed"},
+        )
+
+    assert response.status_code == 400
+    assert response.json() == {"detail": "Invalid OAuth state data"}
+    assert redis.deleted == []
+
+
+@pytest.mark.asyncio
+async def test_oauth_callback_provider_exchange_failure_returns_generic_400(monkeypatch):
+    redis = FakeRedis(
+        json.dumps(
+            {
+                "code_verifier": "verifier",
+                "redirect_uri": "https://azure-docs.midtowntg.com/auth/callback",
+                "provider": "microsoft",
+            }
+        )
+    )
+    monkeypatch.setattr("src.routers.oauth_sso.get_redis", _redis_factory(redis))
+
+    class FakeOAuthService:
+        def __init__(self, db):
+            self.db = db
+
+        async def exchange_code_for_tokens(self, provider, code, redirect_uri, code_verifier):
+            raise OAuthError("upstream secret detail")
+
+    monkeypatch.setattr("src.routers.oauth_sso.OAuthService", FakeOAuthService)
+
+    async with AsyncClient(transport=ASGITransport(app=_app()), base_url="http://test") as client:
+        response = await client.post(
+            "/auth/oauth/callback",
+            json={"provider": "microsoft", "code": "bad-code", "state": "state"},
+        )
+
+    assert response.status_code == 400
+    assert response.json() == {"detail": "OAuth callback failed"}
+    assert "upstream secret detail" not in response.text
+    assert redis.deleted == ["oauth_state:state"]

--- a/api/tests/unit/test_passkeys_router.py
+++ b/api/tests/unit/test_passkeys_router.py
@@ -9,6 +9,12 @@ from src.core.database import get_db
 from src.core.rate_limiting import limiter
 from src.models.enums import UserRole
 from src.routers.passkeys import router
+from src.services.passkey_service import PasskeyValidationError
+
+
+class FakeDb:
+    async def commit(self):
+        pass
 
 
 @pytest.mark.asyncio
@@ -44,3 +50,95 @@ async def test_registration_options_route_accepts_rate_limited_request(monkeypat
 
     assert response.status_code == 200
     assert response.json() == {"options": {"challenge": "abc123", "rp": {"name": "Bifrost Docs"}}}
+
+
+@pytest.mark.asyncio
+async def test_registration_verify_malformed_credential_returns_400(monkeypatch):
+    monkeypatch.setattr(limiter, "enabled", False)
+
+    app = FastAPI()
+    app.include_router(router)
+
+    user = UserPrincipal(
+        user_id=uuid4(),
+        email="test@example.com",
+        name="Test User",
+        role=UserRole.OWNER,
+        is_active=True,
+        is_verified=True,
+    )
+
+    class FakePasskeyService:
+        def __init__(self, db):
+            self.db = db
+
+        async def verify_registration(self, user_id, credential_json, device_name=None):
+            raise PasskeyValidationError("parser detail that should not leak")
+
+    app.dependency_overrides[get_current_active_user] = lambda: user
+    app.dependency_overrides[get_db] = lambda: FakeDb()
+    monkeypatch.setattr("src.routers.passkeys.PasskeyService", FakePasskeyService)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.post(
+            "/auth/passkeys/register/verify",
+            json={"credential": {"not": "webauthn"}},
+        )
+
+    assert response.status_code == 400
+    assert response.json() == {"detail": "Invalid passkey registration response"}
+
+
+@pytest.mark.asyncio
+async def test_authentication_verify_malformed_credential_returns_401(monkeypatch):
+    monkeypatch.setattr(limiter, "enabled", False)
+
+    app = FastAPI()
+    app.include_router(router)
+
+    class FakePasskeyService:
+        def __init__(self, db):
+            self.db = db
+
+        async def verify_authentication(self, challenge_id, credential_json):
+            raise PasskeyValidationError("parser detail that should not leak")
+
+    app.dependency_overrides[get_db] = lambda: FakeDb()
+    monkeypatch.setattr("src.routers.passkeys.PasskeyService", FakePasskeyService)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.post(
+            "/auth/passkeys/authenticate/verify",
+            json={"challenge_id": "challenge", "credential": {"not": "webauthn"}},
+        )
+
+    assert response.status_code == 401
+    assert response.json() == {"detail": "Invalid passkey authentication response"}
+    assert response.headers["www-authenticate"] == "Bearer"
+
+
+@pytest.mark.asyncio
+async def test_authentication_verify_unexpected_error_remains_500(monkeypatch):
+    monkeypatch.setattr(limiter, "enabled", False)
+
+    app = FastAPI()
+    app.include_router(router)
+
+    class FakePasskeyService:
+        def __init__(self, db):
+            self.db = db
+
+        async def verify_authentication(self, challenge_id, credential_json):
+            raise RuntimeError("database exploded")
+
+    app.dependency_overrides[get_db] = lambda: FakeDb()
+    monkeypatch.setattr("src.routers.passkeys.PasskeyService", FakePasskeyService)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.post(
+            "/auth/passkeys/authenticate/verify",
+            json={"challenge_id": "challenge", "credential": {"not": "webauthn"}},
+        )
+
+    assert response.status_code == 500
+    assert response.json() == {"detail": "Failed to verify authentication"}

--- a/api/tests/unit/test_security_headers.py
+++ b/api/tests/unit/test_security_headers.py
@@ -204,6 +204,31 @@ class TestHSTSHeader:
         assert "Strict-Transport-Security" not in response.headers
         clear_settings_cache()
 
+    def test_exception_response_has_production_security_headers(self, monkeypatch):
+        """Test production exception responses keep security headers."""
+        from src.config import clear_settings_cache
+        from src.main import create_app
+
+        monkeypatch.setenv("BIFROST_DOCS_ENVIRONMENT", "production")
+        clear_settings_cache()
+
+        app = create_app()
+
+        @app.get("/boom")
+        def boom():
+            raise RuntimeError("test failure")
+
+        client = TestClient(app, raise_server_exceptions=False)
+        response = client.get("/boom")
+
+        assert response.status_code == 500
+        assert "Strict-Transport-Security" in response.headers
+        assert response.headers["X-Content-Type-Options"] == "nosniff"
+        assert "Content-Security-Policy" in response.headers
+        assert response.headers["Cache-Control"] == "no-cache, no-store, must-revalidate"
+        assert response.json()["message"] == "An unexpected error occurred"
+        clear_settings_cache()
+
 
 class TestCSPDirectives:
     """Tests for Content-Security-Policy directives."""


### PR DESCRIPTION
## Summary
- convert malformed passkey/WebAuthn credential parse and verify failures into stable 4xx responses
- make OAuth callback failures return stable 400 responses without exposing provider/internal details
- preserve security headers on global exception-handler responses
- add unit coverage for passkey, setup passkey, OAuth callback, and production error headers

## Test Plan
- python -m ruff check api/src api/tests
- python -m ruff format --check api/src api/tests
- cd api && python -m pyright src
- cd api && python -m pytest tests/unit -v --cov=src --cov-report=xml --cov-report=term

## Follow-up
- After merge, dispatch OWASP ZAP Authenticated API on main and tune .zap/api-scan-rules.tsv only for verified expected reader-role 403 / placeholder-id 422 noise.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Security headers are now consistently applied to all error responses, including server errors and JSON error payloads.
  * Content-Security-Policy and Strict-Transport-Security behavior adjusted by environment.

* **Bug Fixes**
  * OAuth state is deleted only after successful parsing to prevent premature loss.
  * Passkey errors are sanitized and return consistent HTTP statuses (400 for registration, 401 for authentication) with appropriate WWW-Authenticate header.

* **Tests**
  * Added unit tests for passkey flows, OAuth callback, and security header behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->