### PR TITLE
fix: fail closed on scanner auth state paths

### DIFF
--- a/api/src/routers/oauth_sso.py
+++ b/api/src/routers/oauth_sso.py
@@ -267,6 +267,16 @@ async def oauth_callback(
     oauth_service = OAuthService(db)
     user_repo = UserRepository(db)
 
+    if callback_data.provider not in PROVIDER_INFO:
+        logger.warning(
+            "OAuth callback with invalid provider",
+            extra={"provider": callback_data.provider},
+        )
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid OAuth provider",
+        )
+
     # Validate state and retrieve PKCE verifier + redirect_uri from Redis
     r = await get_redis()
     state_key = _oauth_state_key(callback_data.state)

--- a/api/src/routers/passkeys.py
+++ b/api/src/routers/passkeys.py
@@ -50,6 +50,15 @@ def _to_public(passkey: UserPasskey) -> PasskeyPublic:
     return PasskeyPublic.model_validate(passkey)
 
 
+def _reject_api_key_passkey_enrollment(user: UserPrincipal) -> None:
+    """Passkey enrollment is an interactive browser-user flow."""
+    if user.api_key_id is not None:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Passkey enrollment requires interactive user authentication",
+        )
+
+
 # =============================================================================
 # Registration Endpoints (Authenticated users adding passkeys)
 # =============================================================================
@@ -70,6 +79,7 @@ async def get_registration_options(
     db: DbSession,
 ) -> PasskeyRegistrationOptionsResponse:
     """Generate WebAuthn registration options for the current user."""
+    _reject_api_key_passkey_enrollment(user)
     service = PasskeyService(db)
 
     try:
@@ -103,6 +113,7 @@ async def verify_registration(
     db: DbSession,
 ) -> PasskeyRegistrationVerifyResponse:
     """Verify and complete passkey registration."""
+    _reject_api_key_passkey_enrollment(user)
     service = PasskeyService(db)
 
     try:

--- a/api/src/services/passkey_service.py
+++ b/api/src/services/passkey_service.py
@@ -264,6 +264,11 @@ class PasskeyService:
         Raises:
             ValueError: If verification fails
         """
+        try:
+            credential = parse_authentication_credential_json(credential_json)
+        except Exception as e:
+            raise PasskeyValidationError("Invalid passkey authentication response") from e
+
         # Get and delete challenge from Redis (single-use)
         redis = await get_redis()
         challenge_key = f"{PASSKEY_AUTH_CHALLENGE_PREFIX}{challenge_id}"
@@ -273,11 +278,6 @@ class PasskeyService:
         await redis.delete(challenge_key)
 
         expected_challenge = base64url_to_bytes(challenge_b64)
-
-        try:
-            credential = parse_authentication_credential_json(credential_json)
-        except Exception as e:
-            raise PasskeyValidationError("Invalid passkey authentication response") from e
 
         # Find the passkey by credential ID
         passkey = await self._get_passkey_by_credential_id(credential.raw_id)
@@ -451,6 +451,11 @@ class PasskeyService:
         """
         from src.repositories.user import UserRepository
 
+        try:
+            credential = parse_registration_credential_json(credential_json)
+        except Exception as e:
+            raise PasskeyValidationError("Invalid passkey setup response") from e
+
         # Get and delete setup data from Redis (single-use)
         redis = await get_redis()
         setup_key = f"{PASSKEY_SETUP_TOKEN_PREFIX}{registration_token}"
@@ -462,7 +467,6 @@ class PasskeyService:
         try:
             setup_data = json.loads(setup_data_json)
             expected_challenge = base64url_to_bytes(setup_data["challenge"])
-            credential = parse_registration_credential_json(credential_json)
             verification = verify_registration_response(
                 credential=credential,
                 expected_challenge=expected_challenge,

--- a/api/tests/unit/test_oauth_sso_router.py
+++ b/api/tests/unit/test_oauth_sso_router.py
@@ -56,6 +56,22 @@ async def test_oauth_callback_invalid_state_returns_400(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_oauth_callback_invalid_provider_returns_400_before_state_lookup(monkeypatch):
+    redis = FakeRedis("should-not-be-read")
+    monkeypatch.setattr("src.routers.oauth_sso.get_redis", _redis_factory(redis))
+
+    async with AsyncClient(transport=ASGITransport(app=_app()), base_url="http://test") as client:
+        response = await client.post(
+            "/auth/oauth/callback",
+            json={"provider": "provider", "code": "code", "state": "state"},
+        )
+
+    assert response.status_code == 400
+    assert response.json() == {"detail": "Invalid OAuth provider"}
+    assert redis.deleted == []
+
+
+@pytest.mark.asyncio
 async def test_oauth_callback_malformed_cached_state_returns_400_without_consuming_state(
     monkeypatch,
 ):

--- a/api/tests/unit/test_passkeys_router.py
+++ b/api/tests/unit/test_passkeys_router.py
@@ -53,6 +53,34 @@ async def test_registration_options_route_accepts_rate_limited_request(monkeypat
 
 
 @pytest.mark.asyncio
+async def test_registration_options_rejects_api_key_principal(monkeypatch):
+    monkeypatch.setattr(limiter, "enabled", False)
+
+    app = FastAPI()
+    app.include_router(router)
+
+    user = UserPrincipal(
+        user_id=uuid4(),
+        email="scanner@example.com",
+        role=UserRole.READER,
+        is_active=True,
+        is_verified=True,
+        api_key_id=uuid4(),
+    )
+
+    app.dependency_overrides[get_current_active_user] = lambda: user
+    app.dependency_overrides[get_db] = lambda: object()
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.post("/auth/passkeys/register/options", json={})
+
+    assert response.status_code == 403
+    assert response.json() == {
+        "detail": "Passkey enrollment requires interactive user authentication"
+    }
+
+
+@pytest.mark.asyncio
 async def test_registration_verify_malformed_credential_returns_400(monkeypatch):
     monkeypatch.setattr(limiter, "enabled", False)
 
@@ -87,6 +115,37 @@ async def test_registration_verify_malformed_credential_returns_400(monkeypatch)
 
     assert response.status_code == 400
     assert response.json() == {"detail": "Invalid passkey registration response"}
+
+
+@pytest.mark.asyncio
+async def test_registration_verify_rejects_api_key_principal(monkeypatch):
+    monkeypatch.setattr(limiter, "enabled", False)
+
+    app = FastAPI()
+    app.include_router(router)
+
+    user = UserPrincipal(
+        user_id=uuid4(),
+        email="scanner@example.com",
+        role=UserRole.READER,
+        is_active=True,
+        is_verified=True,
+        api_key_id=uuid4(),
+    )
+
+    app.dependency_overrides[get_current_active_user] = lambda: user
+    app.dependency_overrides[get_db] = lambda: FakeDb()
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.post(
+            "/auth/passkeys/register/verify",
+            json={"credential": {}},
+        )
+
+    assert response.status_code == 403
+    assert response.json() == {
+        "detail": "Passkey enrollment requires interactive user authentication"
+    }
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- reject API-key principals from interactive passkey enrollment flows before WebAuthn/cache work
- parse malformed passkey verify credentials before cache-backed challenge lookups
- reject invalid OAuth callback providers before state lookup

## Test Plan
- python -m ruff check api/src api/tests
- python -m ruff format --check api/src api/tests
- cd api; python -m pyright src
- python -m pytest api/tests/unit/test_passkeys_router.py api/tests/unit/test_auth_setup_passkeys_router.py api/tests/unit/test_oauth_sso_router.py api/tests/unit/services/test_passkey_validation_errors.py api/tests/unit/test_security_headers.py -q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * OAuth callback now validates the provider is recognized before processing requests.
  * Passkey enrollment endpoints now require interactive user authentication and reject API-key-based requests.

* **Tests**
  * Added tests for OAuth provider validation during callback.
  * Added tests for passkey enrollment access control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->