### PR TITLE
Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
+# Default ownership for Bifrost repositories.
 * @MTG-Thomas


### PR DESCRIPTION
Adds a minimal CODEOWNERS file so branch protection can require code-owner review. This is part of MTG-Thomas/bifrost-infra#253.