### PR TITLE
ci: finish docs deployment channel hardening

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -127,9 +127,9 @@ jobs:
             printf 'BIFROST_DOCS_API_IMAGE=%q\n' "${BIFROST_DOCS_API_IMAGE}"
             printf 'BIFROST_DOCS_CLIENT_IMAGE=%q\n' "${BIFROST_DOCS_CLIENT_IMAGE}"
             printf 'GHCR_READ_USER=%q\n' "${GHCR_READ_USER}"
-            printf 'GHCR_READ_TOKEN=%q\n' "${GHCR_READ_TOKEN}"
             printf 'HEALTH_URL=%q\n' "${HEALTH_URL}"
           } > /tmp/bifrost-docs-deploy.env
+          chmod 600 /tmp/bifrost-docs-deploy.env
 
           for attempt in $(seq 1 12); do
             if ssh -i ~/.ssh/test_vm_key -o StrictHostKeyChecking=yes -o ConnectTimeout=10 "${TEST_VM_USER}@${TEST_VM_HOST}" "true"; then
@@ -151,8 +151,18 @@ jobs:
           ssh -i ~/.ssh/test_vm_key -o StrictHostKeyChecking=yes -o ConnectTimeout=10 "${TEST_VM_USER}@${TEST_VM_HOST}" \
             "mkdir -p /tmp/bifrost-docs-deploy && tar -xzf /tmp/bifrost-docs-deploy.tgz -C /tmp/bifrost-docs-deploy"
 
-          ssh -i ~/.ssh/test_vm_key -o StrictHostKeyChecking=yes -o ConnectTimeout=10 "${TEST_VM_USER}@${TEST_VM_HOST}" \
-            "set -a; . /tmp/bifrost-docs-deploy.env; set +a; bash /tmp/bifrost-docs-deploy/scripts/deploy-test-vm.sh; rm -f /tmp/bifrost-docs-deploy.env"
+          printf '%s' "${GHCR_READ_TOKEN}" | \
+            ssh -i ~/.ssh/test_vm_key -o StrictHostKeyChecking=yes -o ConnectTimeout=10 "${TEST_VM_USER}@${TEST_VM_HOST}" \
+              'set -euo pipefail
+              chmod 600 /tmp/bifrost-docs-deploy.env
+              trap "rm -f /tmp/bifrost-docs-deploy.env; docker logout ghcr.io >/dev/null 2>&1 || true" EXIT
+              set -a
+              . /tmp/bifrost-docs-deploy.env
+              set +a
+              ghcr_token="$(cat)"
+              printf "%s" "${ghcr_token}" | docker login ghcr.io -u "${GHCR_READ_USER:-MTG-Thomas}" --password-stdin
+              unset ghcr_token
+              bash /tmp/bifrost-docs-deploy/scripts/deploy-test-vm.sh'
 
       - name: Verify public health
         run: curl -fsS "${HEALTH_URL}"

--- a/scripts/deploy-test-vm.sh
+++ b/scripts/deploy-test-vm.sh
@@ -19,10 +19,6 @@ COMPOSE_FILES=(
 API_IMAGE="${BIFROST_DOCS_API_IMAGE:-ghcr.io/mtg-thomas/bifrost-docs-api:${DEPLOY_SHA_SHORT}}"
 CLIENT_IMAGE="${BIFROST_DOCS_CLIENT_IMAGE:-ghcr.io/mtg-thomas/bifrost-docs-client:${DEPLOY_SHA_SHORT}}"
 
-if [ -n "${GHCR_READ_TOKEN:-}" ]; then
-  echo "${GHCR_READ_TOKEN}" | docker login ghcr.io -u "${GHCR_READ_USER:-MTG-Thomas}" --password-stdin
-fi
-
 mkdir -p "$(dirname "${DEPLOY_ROOT}")"
 
 if [ ! -d "${DEPLOY_ROOT}/.git" ]; then
@@ -52,7 +48,7 @@ docker compose "${COMPOSE_FILES[@]}" up -d --remove-orphans
 docker image prune -f
 
 for attempt in {1..30}; do
-  if curl -fsSk "${HEALTH_URL}" >/dev/null; then
+  if curl -fsS "${HEALTH_URL}" >/dev/null; then
     docker compose "${COMPOSE_FILES[@]}" ps
     echo "Deployment healthy: ${HEALTH_URL}"
     exit 0


### PR DESCRIPTION
## Summary
- keep the ephemeral GHCR token out of the copied deployment environment file
- send it only over pinned-host SSH stdin to docker login, then logout with an EXIT trap
- enforce mode 600 on the non-secret deployment environment file
- require normal TLS verification for the VM-side health gate

## Security
Completes the residual work from Codex Cloud Security finding 496cf616e2d48191ba7c3730fbf0a17c. PR #58 already replaced SSH TOFU with a pinned host key; this removes the remaining token-on-disk and curl -k paths.

## Verification
- actionlint .github/workflows/cd.yml
- bash -n scripts/deploy-test-vm.sh (normalized read because the checkout uses CRLF)
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Improved deployment credential handling by securely passing, limiting, and cleaning up container registry access tokens.
  * Deployment environment files now use stricter permissions and are removed after use.
  * Registry sessions are logged out automatically after deployment.

* **Reliability**
  * Health checks now validate TLS certificates instead of bypassing certificate verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->